### PR TITLE
Add image for Debian 11 Bullseye

### DIFF
--- a/etc/images.yml
+++ b/etc/images.yml
@@ -477,6 +477,27 @@ images:
         url: https://cdimage.debian.org/cdimage/openstack/archive/10.10.1-20210624/debian-10.10.1-20210624-openstack-amd64.qcow2
         os_version: '10.10.1'
 
+  - name: Debian 11
+    format: qcow2
+    login: debian
+    min_disk: 8
+    min_ram: 512
+    status: active
+    visibility: public
+    multi: true
+    meta:
+      architecture: x86_64
+      hw_disk_bus: scsi
+      hw_scsi_model: virtio-scsi
+      hw_watchdog_action: reset
+      os_distro: debian
+      os_version: '11'
+    tags: []
+    versions:
+      - version: '20210814'
+        url: https://cdimage.debian.org/images/cloud/bullseye/20210814-734/debian-11-generic-amd64-20210814-734.qcow2
+        os_version: '11.0.0'
+
   # Fedora
 
   - name: Fedora 34


### PR DESCRIPTION
Added image for Debian 11. There is a new image URL as Debian no longer provides special OpenStack images because the generic images work as well.