### PR TITLE
Update Debian images to 10.12 and 11.3

### DIFF
--- a/etc/images.yml
+++ b/etc/images.yml
@@ -506,11 +506,11 @@ images:
       os_version: '10'
     tags: []
     versions:
-      - version: '20211129'
-        url: https://minio.services.osism.tech/openstack-image-manager/debian-10/20211129/debian-10.11.2-20211129-openstack-amd64.qcow2
-        source: https://cdimage.debian.org/cdimage/openstack/10.11.2-20211129/debian-10.11.2-20211129-openstack-amd64.qcow2
-        checksum: "sha256:77a7390a542af2327f34af940018aa4fbad3b79ad3687b524020f094994950a3"
-        os_version: '10.11.2'
+      - version: '20220326'
+        url: https://minio.services.osism.tech/openstack-image-manager/debian-10/20220326/debian-10.12.0-20220326-openstack-amd64.qcow2
+        source: https://cdimage.debian.org/images/cloud/OpenStack/10.12.0/debian-10.12.0-openstack-amd64.qcow2
+        checksum: "sha256:ce2fc968e938c8b2c7ca3d936225c6a15c6fccc1f5ddac4dfa09053bed0fba99"
+        os_version: '10.12.0'
 
   - name: Debian 11
     shortname: debian-11
@@ -530,11 +530,11 @@ images:
       os_version: '11'
     tags: []
     versions:
-      - version: '20211220'
-        url: https://minio.services.osism.tech/openstack-image-manager/debian-11/20211220/debian-11-generic-amd64-20211220-862.qcow2
-        source: https://cdimage.debian.org/images/cloud/bullseye/20211220-862/debian-11-generic-amd64-20211220-862.qcow2
-        checksum: "sha256:0286808217dca6e39bdbd227c493ae8a3d27b7c5b753a3c0eb37fc1ec50ad6b3"
-        os_version: '11.2.0'
+      - version: '20220328'
+        url: https://minio.services.osism.tech/openstack-image-manager/debian-11/20220328/debian-11-generic-amd64-20220328-962.qcow2
+        source: https://cdimage.debian.org/images/cloud/bullseye/20220328-962/debian-11-generic-amd64-20220328-962.qcow2
+        checksum: "sha256:be6b83fda664af1c6d6a2da4f8841100624c6419081ea8f694af50ea89690d7b"
+        os_version: '11.3.0'
 
   # Fedora
 


### PR DESCRIPTION
- Update Debian Buster to version 10.12
- Update Debian Bullseye to version 11.3