### PR TITLE
etc/images.yml: add AlmaLinux 9 and 8.6, add RockyLinux 8.6, Fedora36 and FedoraCoreOS36

### DIFF
--- a/etc/images.yml
+++ b/etc/images.yml
@@ -485,6 +485,10 @@ images:
       os_version: '8'
     tags: []
     versions:
+      - version: '20220513'
+        url: https://minio.services.osism.tech/openstack-image-manager/almalinux-8/20220513/AlmaLinux-8-GenericCloud-8.6-20220513.x86_64.qcow2
+        source: https://ftp.gwdg.de/pub/linux/almalinux/8.6/cloud/x86_64/images/AlmaLinux-8-GenericCloud-8.6-20220513.x86_64.qcow2
+        checksum: "sha256:1563c0b09d98e7a606e1e737f1c810830aeb0cbe37ac5585f3696be62f0a32b4"
       - version: '20211119'
         url: https://minio.services.osism.tech/openstack-image-manager/almalinux-8/20211119/AlmaLinux-8-GenericCloud-8.5-20211119.x86_64.qcow2
         source: https://ftp.gwdg.de/pub/linux/almalinux/8.5/cloud/x86_64/images/AlmaLinux-8-GenericCloud-8.5-20211119.x86_64.qcow2

--- a/etc/images.yml
+++ b/etc/images.yml
@@ -692,6 +692,29 @@ images:
         source: https://download.fedoraproject.org/pub/fedora/linux/releases/35/Cloud/x86_64/images/Fedora-Cloud-Base-35-1.2.x86_64.qcow2
         checksum: "sha256:fe84502779b3477284a8d4c86731f642ca10dd3984d2b5eccdf82630a9ca2de6"
 
+  - name: Fedora 36
+    shortname: fedora-36
+    format: qcow2
+    login: fedora
+    min_disk: 4
+    min_ram: 512
+    status: active
+    visibility: public
+    multi: true
+    meta:
+      architecture: x86_64
+      hw_disk_bus: scsi
+      hw_scsi_model: virtio-scsi
+      hw_watchdog_action: reset
+      os_distro: fedora
+      os_version: '36'
+    tags: []
+    versions:
+      - version: '20220504'
+        url: https://minio.services.osism.tech/openstack-image-manager/fedora-36/20220504/Fedora-Cloud-Base-36-1.5.x86_64.qcow2
+        source: https://mirror.23m.com/fedora/linux/releases/36/Cloud/x86_64/images/Fedora-Cloud-Base-36-1.5.x86_64.qcow2
+        checksum: "sha256:ca9e514cc2f4a7a0188e7c68af60eb4e573d2e6850cc65b464697223f46b4605"
+
   # openSUSE
 
   - name: openSUSE Tumbleweed

--- a/etc/images.yml
+++ b/etc/images.yml
@@ -486,9 +486,32 @@ images:
     tags: []
     versions:
       - version: '20211119'
-        url: https://minio.services.osism.tech/openstack-image-manager/rocky-8/20211119/AlmaLinux-8-GenericCloud-8.5-20211119.x86_64.qcow2
+        url: https://minio.services.osism.tech/openstack-image-manager/almalinux-8/20211119/AlmaLinux-8-GenericCloud-8.5-20211119.x86_64.qcow2
         source: https://ftp.gwdg.de/pub/linux/almalinux/8.5/cloud/x86_64/images/AlmaLinux-8-GenericCloud-8.5-20211119.x86_64.qcow2
         checksum: "sha256:d629247b12802157be127db53a7fcb484b80fceae9896d750c953a51a8c6688f"
+
+  - name: AlmaLinux 9
+    shortname: almalinux-9
+    format: qcow2
+    login: almalinux
+    min_disk: 10
+    min_ram: 512
+    status: active
+    visibility: public
+    multi: true
+    meta:
+      architecture: x86_64
+      hw_disk_bus: scsi
+      hw_scsi_model: virtio-scsi
+      hw_watchdog_action: reset
+      os_distro: centos
+      os_version: '9'
+    tags: []
+    versions:
+      - version: '20220527'
+        url: https://minio.services.osism.tech/openstack-image-manager/almalinux-9/20220527/AlmaLinux-9-GenericCloud-9.0-20220527.x86_64.qcow2
+        source: https://ftp.gwdg.de/pub/linux/almalinux/9.0/cloud/x86_64/images/AlmaLinux-9-GenericCloud-9.0-20220527.x86_64.qcow2
+        checksum: "sha256:e453dde3dac780c149932f39814e3371cb0b7fe3f758012b86ab6c7a51ec7a42"
 
   # RockyLinux
 

--- a/etc/images.yml
+++ b/etc/images.yml
@@ -537,6 +537,10 @@ images:
       os_version: '8'
     tags: []
     versions:
+      - version: '20220515'
+        url: https://minio.services.osism.tech/openstack-image-manager/rocky-8/20220515/Rocky-8-GenericCloud-8.6-20220515.x86_64.qcow2
+        source: https://download.rockylinux.org/pub/rocky/8.6/images/Rocky-8-GenericCloud-8.6-20220515.x86_64.qcow2
+        checksum: "sha256:77e79f487c70f6bfa5655d8084e02cb8d31900a2c2a22b2334c3401b40a1231c"
       - version: '20211114'
         url: https://minio.services.osism.tech/openstack-image-manager/rocky-8/20211114/Rocky-8-GenericCloud-8.5-20211114.2.x86_64.qcow2
         source: https://download.rockylinux.org/pub/rocky/8.5/images/Rocky-8-GenericCloud-8.5-20211114.2.x86_64.qcow2

--- a/etc/images.yml
+++ b/etc/images.yml
@@ -418,6 +418,10 @@ images:
       os_version: '7'
     tags: []
     versions:
+      - version: '20211116'
+        url: https://minio.services.osism.tech/openstack-image-manager/centos-7/20211116/CentOS-7-x86_64-GenericCloud-2111.qcow2
+        source: https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud-2111.qcow2
+        #checksum: "sha256:"
       - version: '20201112'
         url: https://minio.services.osism.tech/openstack-image-manager/centos-7/20201112/CentOS-7-x86_64-GenericCloud-2009.qcow2
         source: https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud-2009.qcow2

--- a/etc/images.yml
+++ b/etc/images.yml
@@ -94,6 +94,10 @@ images:
       os_distro: fedora-coreos
     tags: []
     versions:
+      - version: '36.20220505.3.2'
+        url: https://minio.services.osism.tech/openstack-image-manager/fedora-coreos/36.20220505.3.2/fedora-coreos-36.20220505.3.2-qemu.x86_64.qcow2
+        source: https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/36.20220505.3.2/x86_64/fedora-coreos-36.20220505.3.2-qemu.x86_64.qcow2.xz
+        checksum: "sha256:671eb590785d4df35fc5548544a490428c2d8996383330b481292d392b3d7f4f"
       - version: '35.20211203.3.0'
         url: https://minio.services.osism.tech/openstack-image-manager/fedora-coreos/35.20211203.3.0/fedora-coreos-35.20211203.3.0-openstack.x86_64.qcow2
         source: https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/35.20211203.3.0/x86_64/fedora-coreos-35.20211203.3.0-openstack.x86_64.qcow2.xz


### PR DESCRIPTION
CentOS7 20211116 is missing the checksum, as I did not find it in the official sha256sum.txt