### PR TITLE
Change default cloud name to openstack

### DIFF
--- a/clouds.yml.sample
+++ b/clouds.yml.sample
@@ -1,6 +1,6 @@
 ---
 clouds:
-  images:
+  openstack:
     auth:
       auth_url: https://api-1.betacloud.de:5000/v3
       username: USER

--- a/documentation/source/usage.rst
+++ b/documentation/source/usage.rst
@@ -4,7 +4,7 @@
 Usage
 =====
 
-The cloud environment to be used can be specified via the ``--cloud`` parameter. The default-value is: `images`.
+The cloud environment to be used can be specified via the ``--cloud`` parameter. The default-value is: `openstack`.
 
 The path to the definitions of the images is set via the parameter ``--images``. The default-value is: `etc/images.yml`.
 

--- a/secure.yml.sample
+++ b/secure.yml.sample
@@ -1,5 +1,5 @@
 ---
 clouds:
-  images:
+  openstack:
     auth:
       password: password

--- a/src/manage.py
+++ b/src/manage.py
@@ -26,7 +26,7 @@ class ImageManager:
             cfg.BoolOpt('latest', help='Only import the latest version of images from type multi', default=True),
             cfg.BoolOpt('use-os-hidden', help='Use the os_hidden property', default=False),
             cfg.BoolOpt('yes-i-really-know-what-i-do', help='Really delete images', default=False),
-            cfg.StrOpt('cloud', help='Cloud name in clouds.yaml', default='images'),
+            cfg.StrOpt('cloud', help='Cloud name in clouds.yaml', default='openstack'),
             cfg.StrOpt('images', help='Path to the directory containing all image files', default='etc/images/'),
             cfg.StrOpt('name', help='Image name to process', default=None),
             cfg.StrOpt('tag', help='Name of the tag used to identify managed images', default='managed_by_osism')

--- a/test/test_manage.py
+++ b/test/test_manage.py
@@ -113,7 +113,7 @@ class TestManage(TestCase):
             current_project_id='123456789',
             image=Proxy
         )
-        mock_connect.assert_called_once_with(cloud='images')
+        mock_connect.assert_called_once_with(cloud='openstack')
 
     @mock.patch('src.manage.openstack.image.v2._proxy.Proxy.images')
     def test_get_images(self, mock_images):


### PR DESCRIPTION
This is the default of the openstacksdk itself.

Closes osism/openstck-image-manager#244

Signed-off-by: Christian Berendt <berendt@osism.tech>