### PR TITLE
Switch to Typer as CLI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 minio==7.1.12
+munch==2.5.0
 natsort==8.2.0
 openstacksdk==0.101.0
 oslo.config==9.0.0
@@ -6,3 +7,4 @@ paramiko==2.11.0
 patool==1.12
 requests==2.28.1
 tabulate==0.8.10
+typer==0.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ minio==7.1.12
 munch==2.5.0
 natsort==8.2.0
 openstacksdk==0.101.0
-oslo.config==9.0.0
 paramiko==2.11.0
 patool==1.12
 requests==2.28.1

--- a/src/mirror.py
+++ b/src/mirror.py
@@ -3,95 +3,102 @@
 import logging
 import os
 import shutil
-import sys
-from urllib.parse import urlparse
-
-from oslo_config import cfg
-from minio import Minio
-from minio.error import S3Error
-from os import listdir
-from os.path import isfile, join
 import patoolib
 import requests
 import yaml
+import typer
+from urllib.parse import urlparse
 
-PROJECT_NAME = 'mirror'
-CONF = cfg.CONF
-opts = [
-    cfg.BoolOpt('debug', help='Enable debug logging', default=False),
-    cfg.BoolOpt('dry-run', help='Do not really do anything', default=False),
-    cfg.StrOpt('images', help='Path to the folder with the image files', default='etc/images/'),
-    cfg.StrOpt('minio-access-key', help='Minio access key'),
-    cfg.StrOpt('minio-secret-key', help='Minio secret key'),
-    cfg.StrOpt('minio-server', help='Minio server', default='minio.services.osism.tech'),
-    cfg.StrOpt('minio-bucket', help='Minio bucket', default='openstack-image-manager')
-]
-CONF.register_cli_opts(opts)
-CONF(sys.argv[1:], project=PROJECT_NAME)
-if CONF.debug:
-    level = logging.DEBUG
-    logging.getLogger("paramiko").setLevel(logging.DEBUG)
-else:
-    level = logging.INFO
-    logging.getLogger("paramiko").setLevel(logging.WARNING)
-logging.basicConfig(format='%(asctime)s - %(message)s', level=level, datefmt='%Y-%m-%d %H:%M:%S')
+from minio import Minio
+from minio.error import S3Error
+from munch import Munch
+from os import listdir
+from os.path import isfile, join
 
-onlyfiles = []
-for f in listdir(CONF.images):
-    if isfile(join(CONF.images, f)):
-        onlyfiles.append(f)
 
-all_images = []
-for file in onlyfiles:
-    with open(join(CONF.images, file)) as fp:
-        data = yaml.load(fp, Loader=yaml.SafeLoader)
-        images = data.get('images')
-        for image in images:
-            all_images.append(image)
+app = typer.Typer(add_completion=False)
 
-client = Minio(
-    CONF.minio_server,
-    access_key=CONF.minio_access_key,
-    secret_key=CONF.minio_secret_key
-)
 
-for image in all_images:
-    for version in image['versions']:
-        if 'source' not in version:
-            continue
+@app.command()
+def main(
+        debug: bool = typer.Option(False, '--debug', help='Enable debug logging'),
+        dry_run: bool = typer.Option(False, '--dry-run', help='Do not perform any changes'),
+        images: str = typer.Option('etc/images/', help='Path to the directory containing all image files'),
+        minio_access_key: str = typer.Option(None, help='Minio access key'),
+        minio_secret_key: str = typer.Option(None, help='Minio secret key'),
+        minio_server: str = typer.Option('minio.services.osism.tech', help='Minio server'),
+        minio_bucket: str = typer.Option('openstack-image-manager', help='Minio bucket')
+):
+    CONF = Munch.fromDict(locals())
 
-        logging.debug("source: %s" % version['source'])
+    if CONF.debug:
+        level = logging.DEBUG
+        logging.getLogger("paramiko").setLevel(logging.DEBUG)
+    else:
+        level = logging.INFO
+        logging.getLogger("paramiko").setLevel(logging.WARNING)
+    logging.basicConfig(format='%(asctime)s - %(message)s', level=level, datefmt='%Y-%m-%d %H:%M:%S')
 
-        path = urlparse(version['source'])
+    onlyfiles = []
+    for f in listdir(CONF.images):
+        if isfile(join(CONF.images, f)):
+            onlyfiles.append(f)
 
-        dirname = "%s/%s" % (image['shortname'], version['version'])
-        filename, fileextension = os.path.splitext(os.path.basename(path.path))
+    all_images = []
+    for file in onlyfiles:
+        with open(join(CONF.images, file)) as fp:
+            data = yaml.load(fp, Loader=yaml.SafeLoader)
+            images = data.get('images')
+            for image in images:
+                all_images.append(image)
 
-        if fileextension not in ['.bz2', '.zip', '.xz']:
-            filename += fileextension
+    client = Minio(
+        CONF.minio_server,
+        access_key=CONF.minio_access_key,
+        secret_key=CONF.minio_secret_key
+    )
 
-        logging.debug("dirname: %s" % dirname)
-        logging.debug("filename: %s" % filename)
+    for image in all_images:
+        for version in image['versions']:
+            if 'source' not in version:
+                continue
 
-        try:
-            client.stat_object(CONF.minio_bucket, os.path.join(dirname, filename))
-            logging.info("'%s' available in '%s'" % (filename, dirname))
-        except S3Error:
-            logging.info("'%s' not yet available in '%s'" % (filename, dirname))
+            logging.debug("source: %s" % version['source'])
 
-            if not CONF.dry_run:
-                logging.info("Downloading '%s'" % version['source'])
-                response = requests.get(version['source'], stream=True)
-                with open(os.path.basename(path.path), 'wb') as fp:
-                    shutil.copyfileobj(response.raw, fp)
-                del response
+            path = urlparse(version['source'])
 
-                if fileextension in ['.bz2', '.zip', '.xz']:
-                    logging.info("Decompressing '%s'" % os.path.basename(path.path))
-                    patoolib.extract_archive(os.path.basename(path.path), outdir='.')
-                    os.remove(os.path.basename(path.path))
+            dirname = "%s/%s" % (image['shortname'], version['version'])
+            filename, fileextension = os.path.splitext(os.path.basename(path.path))
 
-                logging.info("Uploading '%s' to '%s'" % (filename, dirname))
+            if fileextension not in ['.bz2', '.zip', '.xz']:
+                filename += fileextension
 
-                client.fput_object(CONF.minio_bucket, os.path.join(dirname, filename), filename)
-                os.remove(filename)
+            logging.debug("dirname: %s" % dirname)
+            logging.debug("filename: %s" % filename)
+
+            try:
+                client.stat_object(CONF.minio_bucket, os.path.join(dirname, filename))
+                logging.info("'%s' available in '%s'" % (filename, dirname))
+            except S3Error:
+                logging.info("'%s' not yet available in '%s'" % (filename, dirname))
+
+                if not CONF.dry_run:
+                    logging.info("Downloading '%s'" % version['source'])
+                    response = requests.get(version['source'], stream=True)
+                    with open(os.path.basename(path.path), 'wb') as fp:
+                        shutil.copyfileobj(response.raw, fp)
+                    del response
+
+                    if fileextension in ['.bz2', '.zip', '.xz']:
+                        logging.info("Decompressing '%s'" % os.path.basename(path.path))
+                        patoolib.extract_archive(os.path.basename(path.path), outdir='.')
+                        os.remove(os.path.basename(path.path))
+
+                    logging.info("Uploading '%s' to '%s'" % (filename, dirname))
+
+                    client.fput_object(CONF.minio_bucket, os.path.join(dirname, filename), filename)
+                    os.remove(filename)
+
+
+if __name__ == '__main__':
+    app()

--- a/src/share.py
+++ b/src/share.py
@@ -1,27 +1,53 @@
 import logging
-import sys
 import os
+import typer
 
-from oslo_config import cfg
+from munch import Munch
 import openstack
 
+
 logging.basicConfig(format='%(asctime)s - %(message)s', level=logging.INFO, datefmt='%Y-%m-%d %H:%M:%S')
-
-PROJECT_NAME = 'glance-share-image'
-CONF = cfg.CONF
-opts = [
-    cfg.BoolOpt('dry-run', help='Do not really do anything', default=False),
-    cfg.StrOpt('action', required=False, help='Action', default='add'),
-    cfg.StrOpt('cloud', required=False, help='Managed cloud', default='service'),
-    cfg.StrOpt('image', required=True, help='Image to share'),
-    cfg.StrOpt('project-domain', required=False, help='Target project domain', default='default'),
-    cfg.StrOpt('target', required=True, help='Target project or domain'),
-    cfg.StrOpt('type', required=True, help='Project or domain', default='project')
-]
-CONF.register_cli_opts(opts)
+app = typer.Typer(add_completion=False)
 
 
-def unshare_image_with_project(conn, image, project):
+@app.command()
+def main(
+        dry_run: bool = typer.Option(False, '--dry-run', help='Do not perform any changes'),
+        action: str = typer.Option('add', help='Action'),
+        cloud: str = typer.Option('service', help='Managed cloud'),
+        image: str = typer.Option(..., help='Image to share'),
+        project_domain: str = typer.Option('default', help='Target project domain'),
+        target: str = typer.Option(..., help='Target project domain'),
+        type: str = typer.Option('project', help='Project or domain')
+):
+    CONF = Munch.fromDict(locals())
+
+    if "OS_AUTH_URL" in os.environ:
+        conn = openstack.connect()
+    else:
+        conn = openstack.connect(cloud=CONF.cloud)
+    image = conn.get_image(CONF.image)
+
+    if CONF.type == "project":
+        domain = conn.get_domain(name_or_id=CONF.project_domain)
+        project = conn.get_project(CONF.target, domain_id=domain.id)
+
+        if CONF.action == "add":
+            share_image_with_project(CONF, conn, image, project)
+        elif CONF.action == "del":
+            unshare_image_with_project(CONF, conn, image, project)
+
+    elif CONF.type == "domain":
+        domain = conn.get_domain(name_or_id=CONF.target)
+        projects = conn.list_projects(domain_id=domain.id)
+        for project in projects:
+            if CONF.action == "add":
+                share_image_with_project(CONF, conn, image, project)
+            elif CONF.action == "del":
+                unshare_image_with_project(CONF, conn, image, project)
+
+
+def unshare_image_with_project(CONF, conn, image, project):
     member = conn.image.find_member(project.id, image.id)
 
     if member:
@@ -31,7 +57,7 @@ def unshare_image_with_project(conn, image, project):
             conn.image.remove_member(member, image.id)
 
 
-def share_image_with_project(conn, image, project):
+def share_image_with_project(CONF, conn, image, project):
     member = conn.image.find_member(project.id, image.id)
 
     if not member:
@@ -46,29 +72,4 @@ def share_image_with_project(conn, image, project):
 
 
 if __name__ == '__main__':
-    CONF(sys.argv[1:], project=PROJECT_NAME)
-
-    if "OS_AUTH_URL" in os.environ:
-        conn = openstack.connect()
-    else:
-        conn = openstack.connect(cloud=CONF.cloud)
-
-    image = conn.get_image(CONF.image)
-
-    if CONF.type == "project":
-        domain = conn.get_domain(name_or_id=CONF.project_domain)
-        project = conn.get_project(CONF.target, domain_id=domain.id)
-
-        if CONF.action == "add":
-            share_image_with_project(conn, image, project)
-        elif CONF.action == "del":
-            unshare_image_with_project(conn, image, project)
-
-    elif CONF.type == "domain":
-        domain = conn.get_domain(name_or_id=CONF.target)
-        projects = conn.list_projects(domain_id=domain.id)
-        for project in projects:
-            if CONF.action == "add":
-                share_image_with_project(conn, image, project)
-            elif CONF.action == "del":
-                unshare_image_with_project(conn, image, project)
+    app()

--- a/src/table.py
+++ b/src/table.py
@@ -1,39 +1,45 @@
-import sys
-
-from oslo_config import cfg
-from os import listdir
-from os.path import isfile, join
 import tabulate
+import typer
 import yaml
 
-PROJECT_NAME = 'table'
-CONF = cfg.CONF
-opts = [
-    cfg.StrOpt('images', help='Path to the folder with the image files', default='etc/images/')
-]
-CONF.register_cli_opts(opts)
-CONF(sys.argv[1:], project=PROJECT_NAME)
+from munch import Munch
+from os import listdir
+from os.path import isfile, join
 
-onlyfiles = []
-for f in listdir(CONF.images):
-    if isfile(join(CONF.images, f)):
-        onlyfiles.append(f)
 
-all_images = []
-for file in onlyfiles:
-    with open(join(CONF.images, file)) as fp:
-        data = yaml.load(fp, Loader=yaml.SafeLoader)
-        images = data.get('images')
-        for image in images:
-            all_images.append(image)
+app = typer.Typer(add_completion=False)
 
-data = []
-for image in all_images:
-    data.append([image['name'], image['login'], image.get('password', '')])
 
-result = tabulate.tabulate(
-    sorted(data),
-    headers=['Name', 'Login user', 'Password'],
-    tablefmt="rst"
-)
-print(result)
+@app.command()
+def main(
+    images: str = typer.Option('etc/images/', help='Path to the directory containing all image files')
+):
+    CONF = Munch.fromDict(locals())
+
+    onlyfiles = []
+    for f in listdir(CONF.images):
+        if isfile(join(CONF.images, f)):
+            onlyfiles.append(f)
+
+    all_images = []
+    for file in onlyfiles:
+        with open(join(CONF.images, file)) as fp:
+            data = yaml.load(fp, Loader=yaml.SafeLoader)
+            images = data.get('images')
+            for image in images:
+                all_images.append(image)
+
+    data = []
+    for image in all_images:
+        data.append([image['name'], image['login'], image.get('password', '')])
+
+    result = tabulate.tabulate(
+        sorted(data),
+        headers=['Name', 'Login user', 'Password'],
+        tablefmt="rst"
+    )
+    print(result)
+
+
+if __name__ == '__main__':
+    app()

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,10 @@ commands =
 commands =
     python src/share.py {posargs}
 
+[testenv:table]
+commands =
+    python src/table.py {posargs}
+
 [testenv:test]
 commands =
     python -m unittest discover {posargs}


### PR DESCRIPTION
Closes https://github.com/osism/openstack-image-manager/issues/314 and https://github.com/osism/openstack-image-manager/issues/240.

Use a Munch object instead of oslo.CONF, so most of the codebase can stay the same.
`--latest` is now `False` by default, to bring it in line with all other bool options.
To pass multiple image names, `--name` has to be called multiple times.

* Remove `oslo.config` from requirements.txt
* Add Tox environment for table.py