### PR TITLE
Use latest pointer URLs

### DIFF
--- a/test/integration/test_manage_api.py
+++ b/test/integration/test_manage_api.py
@@ -57,7 +57,7 @@ class TestManageAPI(TestCase):
         self.assertFalse(imported_image.is_hidden)
 
         # test set properties
-        self.sot.set_properties(self.image, self.name, {'1': dict()}, '1')
+        self.sot.set_properties(self.image, self.name, {'1': dict()}, '1', '')
 
         # assert the properties of the image got updated
         image = self.sot.get_images()[self.name]

--- a/test/unit/test_manage.py
+++ b/test/unit/test_manage.py
@@ -172,7 +172,7 @@ class TestManage(TestCase):
         self.assertEqual(mock_get_images.call_count, 2)
         mock_requests.assert_called_once_with(self.fake_url)
         mock_import_image.assert_called_once_with(self.fake_image_dict, self.fake_name, self.fake_url)
-        mock_set_properties.assert_called_once_with(self.fake_image_dict, self.fake_name, self.versions, '1')
+        mock_set_properties.assert_called_once_with(self.fake_image_dict, self.fake_name, self.versions, '1', '')
         self.assertEqual(result, ({self.fake_image_dict['name']}, mock_get_images.return_value.__getitem__(), None))
 
         mock_get_images.reset_mock()
@@ -203,7 +203,7 @@ class TestManage(TestCase):
         self.fake_image_dict['tags'] = ['my_tag']
         self.fake_image_dict['status'] = 'deactivated'
 
-        self.sot.set_properties(self.fake_image_dict, self.fake_name, self.versions, '1')
+        self.sot.set_properties(self.fake_image_dict, self.fake_name, self.versions, '1', '')
 
         mock_get_images.assert_called_once()
         mock_update_image.assert_called()


### PR DESCRIPTION
This adds the possibility to use latest pointer URLs (e.g. from Debian, Ubuntu or Rocky) to check if a new image is available. This mechanism is optionally usable by setting the image version to `'latest'` and providing the URL of the checksums file in the corresponding yaml file.
Due to the absence of version numbers when using latest, the last modification date of the upstream image file gets retrieved and used as the `internal_version` image property. If this date cannot be retrieved, set the `internal_version` to `'latest'` temporarily and use the creation date from OpenStack as soon as a newer image gets uploaded.

A possible config in images.yml would look like this:
```yaml
versions:
  - version: 'latest'
    url: https://cloud.debian.org/images/cloud/bullseye/latest/debian-11-generic-amd64.qcow2
    checksums_url: https://cloud.debian.org/images/cloud/bullseye/latest/SHA512SUMS
```