### PR TITLE
Document use of OS_CLIENT_CONFIG_FILE

### DIFF
--- a/.github/clouds.yml
+++ b/.github/clouds.yml
@@ -1,8 +1,5 @@
 ---
 # NOTE: This is the clouds.yml file for the integration tests run by GitHub Actions.
-#
-#       The file will be moved from to the .github direct after implementation
-#       of https://github.com/osism/openstack-image-manager/issues/316.
 
 clouds:
   openstack:

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -30,3 +30,5 @@ jobs:
           python-version: '3.x'
       - run: pip3 install tox
       - run: tox -e test -- test/integration
+        env:
+          OS_CLIENT_CONFIG_FILE: .github/clouds.yml

--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -41,6 +41,10 @@ Usage
 
 The cloud environment to be used can be specified via the ``--cloud`` parameter. The default-value is: `openstack`.
 
+The path of the ``clouds.yaml`` file to be used can be set via the environment variable ``OS_CLIENT_CONFIG_FILE``.
+
+OS_CLIENT_CONFIG_FILE
+
 The path to the definitions of the images is set via the parameter ``--images``. The default-value is: `etc/images.yml`.
 
 The tag for the identification of managed images is set via ``--tag``. The default-value is: `managed_by_osism`.


### PR DESCRIPTION
Closes osism/openstack-image-manager#316

Signed-off-by: Christian Berendt <berendt@osism.tech>