### PR TITLE
Validate yaml schema with yamale

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -16,6 +16,7 @@ pbr = "==5.11.0"
 requests = "==2.28.1"
 tabulate = "==0.9.0"
 typer = {version = "==0.7.0", extras = ["all"]}
+yamale = "==4.0.4"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "529a871e9bd608a22425bed98ebd8b430cb17f1ff4e7aa43513d3346690bf10c"
+            "sha256": "93e9572ed49b468b5eae5f3169a4096aa156389b7befdcda44ff1e46abc10e04"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -554,6 +554,14 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' and python_version < '4'",
             "version": "==1.26.12"
+        },
+        "yamale": {
+            "hashes": [
+                "sha256:04f914c0886bda03ac20f8468272cfd9374a634a062549490eff2beedeb30497",
+                "sha256:e524caf71cbbbd15aa295e8bdda01688ac4b5edaf38dd60851ddff6baef383ba"
+            ],
+            "index": "pypi",
+            "version": "==4.0.4"
         }
     },
     "develop": {}

--- a/etc/schema.yaml
+++ b/etc/schema.yaml
@@ -1,0 +1,49 @@
+---
+images: list(include('image'), min=1)
+
+---
+image:
+  name: str()
+  shortname: str(required=False)
+  format: enum('aki', 'ari', 'ami', 'raw', 'iso', 'vhd', 'vdi', 'qcow2', 'vmdk')
+  login: str()
+  password: str(required=False)
+  min_disk: int(min=0)
+  min_ram: int(min=0)
+  status: enum('active', 'deactivated')
+  visibility: enum('public', 'private', 'community', 'shared')
+  multi: bool()
+  meta: include('meta', required=True)
+  tags: list(str())
+  latest_checksum_url: regex('^(http|ftp)s?:\/\/\w+.*', name='valid URL', required=False)
+  latest_url: regex('^(http|ftp)s?:\/\/\w+.*', name='valid URL', required=False)
+  versions: list(include('versions'))
+
+---
+meta:
+  architecture: enum('x86_64', 'aarch64', 'risc-v')
+  hw_disk_bus: enum('virtio', 'scsi', None)
+  hw_rng_model: enum('virtio', None, required=False)
+  hw_scsi_model: enum('virtio-scsi', required=False)
+  hw_watchdog_action: enum('disabled', 'reset', 'poweroff', 'pause', 'none', required=False)
+  os_distro: enum('arch', 'centos', 'debian', 'fedora', 'opensuse', 'rhel', 'ubuntu', 'windows')
+  os_version: str()
+  patchlevel: str(required=False)
+  replace_frequency: enum('yearly', 'quarterly', 'monthly', 'weekly', 'daily', 'critical_bug', 'never', required=False)
+  uuid_validity: any('none', 'forever', 'notice', str(starts_with='last-'), day(), required=False)
+  provided_until: day(required=False)
+  hotfix_hours: int(min=0, required=False)
+
+---
+versions:
+  version: str()
+  hidden: bool(required=False)
+  visibility: enum('public', 'private', 'community', 'shared', required=False)
+  os_version: str(required=False)
+  url: regex('^(http|ftp)s?:\/\/\w+.*', name='valid URL')
+  checksum: regex('\w+:([a-f0-9]{32}|[a-f0-9]{40}|[a-f0-9]{64}|[a-f0-9]{128})$', name='valid checksum', required=False)
+  source: regex('^(http|ftp)s?:\/\/\w+.*|^private$', name='valid URL or private', required=False)
+  checksums_url: regex('^(http|ftp)s?:\/\/\w+.*', name='valid URL', required=False)
+  build_date: any(day(), timestamp(), required=False)
+  image_description: str(required=False)
+  meta: include('meta', required=False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ requests==2.28.1
 ruamel.yaml==0.17.21
 tabulate==0.9.0
 typer[all]==0.7.0
+yamale==4.0.4


### PR DESCRIPTION
Closes #360.

The YAML schema includes the same fields as the `check_image_metadata()` method.
Some fields such as `uuid_validity`, `provided_until`, `image_source` or `image_description` are mandatory according to the spec, but are not yet included into the image.yaml files.
So these fields are marked as not required for now.

Merge after #387 and #388.