### PR TITLE
Remove old flatcar images and add latest stable release

### DIFF
--- a/etc/images/flatcar.yml
+++ b/etc/images/flatcar.yml
@@ -17,11 +17,7 @@ images:
       hw_watchdog_action: reset
     tags: []
     versions:
-      - version: '2905.2.1'
-        url: https://minio.services.osism.tech/openstack-image-manager/flatcar/2905.2.1/flatcar_production_openstack_image.img
-        source: https://stable.release.flatcar-linux.net/amd64-usr/2905.2.1/flatcar_production_openstack_image.img.bz2
-        checksum: "sha256:d4f1b5086e5446474e24d11068bf8c8201e4e8dc153c99dc33c56ffbe7e37d97"
-      - version: '3033.2.0'
-        url: https://minio.services.osism.tech/openstack-image-manager/flatcar/3033.2.0/flatcar_production_openstack_image.img
-        source: https://stable.release.flatcar-linux.net/amd64-usr/3033.2.0/flatcar_production_openstack_image.img.bz2
-        checksum: "sha256:f1d4b6f229af0937451097cd532eca542a9d9eb07239d145e507307ab45b2c8b"
+      - version: '3227.2.4'
+        url: https://minio.services.osism.tech/openstack-image-manager/flatcar/3227.2.4/flatcar_production_openstack_image.img
+        source: https://stable.release.flatcar-linux.net/amd64-usr/3227.2.4/f/flatcar_production_openstack_image.img.bz2
+        checksum: "sha256:774a4fd77da47a7c91714e6424891d6887ed7b9b72daadc40d56bb2f7527b4f5"


### PR DESCRIPTION
Part of osism/openstack-image-manager#341

Signed-off-by: Christian Berendt <berendt@osism.tech>