### PR TITLE
Use cirros 0.6.0

### DIFF
--- a/etc/images/cirros.yml
+++ b/etc/images/cirros.yml
@@ -18,6 +18,6 @@ images:
       os_distro: ubuntu
     tags: []
     versions:
-      - version: '0.5.2'
-        url: https://github.com/cirros-dev/cirros/releases/download/0.5.2/cirros-0.5.2-x86_64-disk.img
-        checksum: "sha256:932fcae93574e242dc3d772d5235061747dfe537668443a1f0567d893614b464"
+      - version: '0.6.0'
+        url: https://github.com/cirros-dev/cirros/releases/download/0.6.0/cirros-0.6.0-x86_64-disk.img
+        checksum: "sha256:94e1e2c94dbbae7d4bdc38e68590a1daf73c9de2d03dd693857b4b0a042548e8"


### PR DESCRIPTION
Part of osism/openstack-image-manager#341

Signed-off-by: Christian Berendt <berendt@osism.tech>