### PR TITLE
Fix 'is not a day/timestamp' issue

### DIFF
--- a/etc/images/centos.yml
+++ b/etc/images/centos.yml
@@ -78,4 +78,4 @@ images:
       - version: '20221111'
         url: https://minio.services.osism.tech/openstack-image-manager/centos-stream-9/20221111-centos-stream-9.qcow2
         checksum: sha256:6bed5b2fe4bd2ff2cc62210a9fc2a7f55e129f0b1549a07ed26c42f8fa16ce4e
-        build_date: '2022-11-11'
+        build_date: 2022-11-11

--- a/etc/images/debian.yml
+++ b/etc/images/debian.yml
@@ -52,4 +52,4 @@ images:
       - version: '20221109'
         url: https://minio.services.osism.tech/openstack-image-manager/debian-11/20221109-debian-11.qcow2
         checksum: sha512:71f1c376e585a87299f751e076689d7ebe2a897649b65071878eb5694be76b771f37c21d7a88630214f4650dec5307e9f73d597ec326f99bd3451e23f607e5b8
-        build_date: '2022-11-09'
+        build_date: 2022-11-09

--- a/etc/images/ubuntu.yml
+++ b/etc/images/ubuntu.yml
@@ -162,7 +162,7 @@ images:
       - version: '20221107'
         url: https://minio.services.osism.tech/openstack-image-manager/ubuntu-20.04/20221107-ubuntu-20.04.qcow2
         checksum: sha256:b6d04d7ed478a083547eebf009228dc72afade79fcbc097f95226512056bbc2e
-        build_date: '2022-11-07'
+        build_date: 2022-11-07
   - name: Ubuntu 20.04 Minimal
     shortname: ubuntu-20.04-minimal
     format: qcow2
@@ -217,7 +217,7 @@ images:
       - version: '20221110'
         url: https://minio.services.osism.tech/openstack-image-manager/ubuntu-22.04/20221110-ubuntu-22.04.qcow2
         checksum: sha256:fe35607e272c86fa96b33f5d441885a5c5d977b81a391ad3391420ea477450a9
-        build_date: '2022-11-10'
+        build_date: 2022-11-10
   - name: Ubuntu 22.04 Minimal
     shortname: ubuntu-22.04-minimal
     format: qcow2


### PR DESCRIPTION
2022-11-13 21:04:01 | ERROR    | validate_yaml_schema:748 - Error validating data 'etc/images/debian.yml' with 'etc/schema.yaml'
2022-11-13 21:04:01 | ERROR    | validate_yaml_schema:750 - 	images.1.versions.0.build_date: '2022-11-09' is not a day.
2022-11-13 21:04:01 | ERROR    | validate_yaml_schema:750 - 	images.1.versions.0.build_date: '2022-11-09' is not a timestamp.

Signed-off-by: Christian Berendt <berendt@osism.tech>