### PR TITLE
Add: hw_rng_model: virtio to Linux Distro's

### DIFF
--- a/etc/images/almalinux.yml
+++ b/etc/images/almalinux.yml
@@ -12,6 +12,7 @@ images:
     meta:
       architecture: x86_64
       hw_disk_bus: scsi
+      hw_rng_model: virtio
       hw_scsi_model: virtio-scsi
       hw_watchdog_action: reset
       os_distro: centos
@@ -39,6 +40,7 @@ images:
     meta:
       architecture: x86_64
       hw_disk_bus: scsi
+      hw_rng_model: virtio
       hw_scsi_model: virtio-scsi
       hw_watchdog_action: reset
       os_distro: centos

--- a/etc/images/centos.yml
+++ b/etc/images/centos.yml
@@ -12,6 +12,7 @@ images:
     meta:
       architecture: x86_64
       hw_disk_bus: scsi
+      hw_rng_model: virtio
       hw_scsi_model: virtio-scsi
       hw_watchdog_action: reset
       os_distro: centos
@@ -39,6 +40,7 @@ images:
     meta:
       architecture: x86_64
       hw_disk_bus: scsi
+      hw_rng_model: virtio
       hw_scsi_model: virtio-scsi
       hw_watchdog_action: reset
       os_distro: centos
@@ -66,6 +68,7 @@ images:
     meta:
       architecture: x86_64
       hw_disk_bus: scsi
+      hw_rng_model: virtio
       hw_scsi_model: virtio-scsi
       hw_watchdog_action: reset
       os_distro: centos

--- a/etc/images/cirros.yml
+++ b/etc/images/cirros.yml
@@ -13,6 +13,7 @@ images:
     meta:
       architecture: x86_64
       hw_disk_bus: scsi
+      hw_rng_model: virtio
       hw_scsi_model: virtio-scsi
       hw_watchdog_action: reset
       os_distro: cirros

--- a/etc/images/clearlinux.yml
+++ b/etc/images/clearlinux.yml
@@ -13,6 +13,7 @@ images:
     meta:
       architecture: x86_64
       hw_disk_bus: scsi
+      hw_rng_model: virtio
       hw_scsi_model: virtio-scsi
       hw_watchdog_action: reset
       os_distro: clearlinux

--- a/etc/images/debian.yml
+++ b/etc/images/debian.yml
@@ -12,6 +12,7 @@ images:
     meta:
       architecture: x86_64
       hw_disk_bus: scsi
+      hw_rng_model: virtio
       hw_scsi_model: virtio-scsi
       hw_watchdog_action: reset
       os_distro: debian

--- a/etc/images/fedora-coreos.yml
+++ b/etc/images/fedora-coreos.yml
@@ -13,6 +13,7 @@ images:
     meta:
       architecture: x86_64
       hw_disk_bus: scsi
+      hw_rng_model: virtio
       hw_scsi_model: virtio-scsi
       hw_watchdog_action: reset
       os_distro: fedora

--- a/etc/images/fedora.yml
+++ b/etc/images/fedora.yml
@@ -14,6 +14,7 @@ images:
       architecture: x86_64
       hw_disk_bus: scsi
       hw_scsi_model: virtio-scsi
+      hw_rng_model: virtio
       hw_watchdog_action: reset
       os_distro: fedora
       os_version: '36'

--- a/etc/images/flatcar.yml
+++ b/etc/images/flatcar.yml
@@ -13,6 +13,7 @@ images:
     meta:
       architecture: x86_64
       hw_disk_bus: scsi
+      hw_rng_model: virtio
       hw_scsi_model: virtio-scsi
       hw_watchdog_action: reset
       os_distro: fedora

--- a/etc/images/gardenlinux.yml
+++ b/etc/images/gardenlinux.yml
@@ -12,6 +12,7 @@ images:
     meta:
       architecture: x86_64
       hw_disk_bus: virtio
+      hw_rng_model: virtio
       hw_scsi_model: virtio-scsi
       hw_watchdog_action: reset
       os_distro: debian

--- a/etc/images/kubernetes.yml
+++ b/etc/images/kubernetes.yml
@@ -12,6 +12,7 @@ images:
     meta:
       architecture: x86_64
       hw_disk_bus: virtio
+      hw_rng_model: virtio
       hw_scsi_model: virtio-scsi
       hw_watchdog_action: reset
       os_distro: ubuntu

--- a/etc/images/opensense.yml
+++ b/etc/images/opensense.yml
@@ -14,6 +14,7 @@ images:
     meta:
       architecture: x86_64
       hw_disk_bus: scsi
+      hw_rng_model: virtio
       hw_scsi_model: virtio-scsi
       hw_watchdog_action: reset
       os_distro: freebsd

--- a/etc/images/opensuse.yml
+++ b/etc/images/opensuse.yml
@@ -12,6 +12,7 @@ images:
     meta:
       architecture: x86_64
       hw_disk_bus: scsi
+      hw_rng_model: virtio
       hw_scsi_model: virtio-scsi
       hw_watchdog_action: reset
       os_distro: opensuse

--- a/etc/images/rockylinux.yml
+++ b/etc/images/rockylinux.yml
@@ -12,6 +12,7 @@ images:
     meta:
       architecture: x86_64
       hw_disk_bus: scsi
+      hw_rng_model: virtio
       hw_scsi_model: virtio-scsi
       hw_watchdog_action: reset
       os_distro: centos
@@ -39,6 +40,7 @@ images:
     meta:
       architecture: x86_64
       hw_disk_bus: scsi
+      hw_rng_model: virtio
       hw_scsi_model: virtio-scsi
       hw_watchdog_action: reset
       os_distro: centos


### PR DESCRIPTION
For flavors  it should  set the  following values:

hw_rng:allowed=True
hw_rng:rate_bytes - The allowed amount of bytes for the the guest to read from the host’s entropy per period. hw_rng:rate_period

Signed-off-by: Mathias Fechner <fechner@osism.tech>