### PR TITLE
Add etc/images/*.yml to package data

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,12 @@ classifier =
    Programming Language :: Python :: 3.9
    Programming Language :: Python :: 3.10
 
+[options]
+include_package_data = True
+
+[options.package_data]
+* = etc/images/*.yml
+
 [files]
 packages =
     openstack_image_manager


### PR DESCRIPTION
This way it is possible to use the image definition included
 within the project directly after the installation via PyPi.

Signed-off-by: Christian Berendt <berendt@osism.tech>