### PR TITLE
Fix schema validation error

### DIFF
--- a/etc/images/almalinux.yml
+++ b/etc/images/almalinux.yml
@@ -27,7 +27,7 @@ images:
       - version: '20221111'
         url: https://minio.services.osism.tech/openstack-image-manager/almalinux-8/20221111-almalinux-8.qcow2
         checksum: sha256:9505239cbaf56fae0abc93a2dba312606540014fcc01e74f196edac0b5fbe783
-        build_date: '2022-11-11'
+        build_date: 2022-11-11
   - name: AlmaLinux 9
     shortname: almalinux-9
     format: qcow2
@@ -55,4 +55,4 @@ images:
       - version: '20221118'
         url: https://minio.services.osism.tech/openstack-image-manager/almalinux-9/20221118-almalinux-9.qcow2
         checksum: sha256:1e93210a0c534de76ae01dc02e8224be14264fa8d54ad6cff9af15b673c6db1a
-        build_date: '2022-11-18'
+        build_date: 2022-11-18

--- a/etc/images/centos.yml
+++ b/etc/images/centos.yml
@@ -83,4 +83,4 @@ images:
       - version: '20230208'
         url: https://minio.services.osism.tech/openstack-image-manager/centos-stream-9/20230208-centos-stream-9.qcow2
         checksum: sha256:5840c367e4e93233661bde632e9d940996e6ba80cabc3cad4c3fa9818f7e1aa6
-        build_date: '2023-02-08'
+        build_date: 2023-02-08

--- a/etc/images/debian.yml
+++ b/etc/images/debian.yml
@@ -27,7 +27,7 @@ images:
       - version: '20221224'
         url: https://minio.services.osism.tech/openstack-image-manager/debian-10/20221224-debian-10.qcow2
         checksum: sha512:c8950be15827fd833379d9b5f3c84e84c11fd6c7af54436d82786cbccee8f742577eaee85adcfc5044017099102351979b5e73a1fe3ccd829088c68b66ee8d8b
-        build_date: '2022-12-24'
+        build_date: 2022-12-24
   - name: Debian 11
     shortname: debian-11
     format: qcow2
@@ -54,4 +54,4 @@ images:
       - version: '20230124'
         url: https://minio.services.osism.tech/openstack-image-manager/debian-11/20230124-debian-11.qcow2
         checksum: sha512:7a7a546b9928f0d375c332a39db2d1af56fce3432b8a5dee0d4f71777efa7463a6b1fc797bcf3b12ca7d8f47d66824abbcbf0a0bdc94be5e90e5a90e8628fae6
-        build_date: '2023-01-24'
+        build_date: 2023-01-24

--- a/etc/images/ubuntu.yml
+++ b/etc/images/ubuntu.yml
@@ -111,7 +111,7 @@ images:
       - version: '20230203'
         url: https://minio.services.osism.tech/openstack-image-manager/ubuntu-18.04/20230203-ubuntu-18.04.qcow2
         checksum: sha256:9cb086803822ee3e3950d310901e471c958dc79b4805b3f60172c1c08b5c0064
-        build_date: '2023-02-03'
+        build_date: 2023-02-03
   - name: Ubuntu 18.04 Minimal
     shortname: ubuntu-18.04-minimal
     format: qcow2
@@ -139,7 +139,7 @@ images:
       - version: '20230208'
         url: https://minio.services.osism.tech/openstack-image-manager/ubuntu-18.04-minimal/20230208-ubuntu-18.04-minimal.qcow2
         checksum: sha256:ef36b8e2bb82bba4d8fbd21327a58572feda07ea6970a829b8c6c6bd4eedd5d4
-        build_date: '2023-02-08'
+        build_date: 2023-02-08
   - name: Ubuntu 20.04
     shortname: ubuntu-20.04
     format: qcow2
@@ -167,7 +167,7 @@ images:
       - version: '20230207'
         url: https://minio.services.osism.tech/openstack-image-manager/ubuntu-20.04/20230207-ubuntu-20.04.qcow2
         checksum: sha256:3e49874b7fe9cbb4109f8fd4c4bc3ad38cd4b375f8b11b784669d96df1ff8c3c
-        build_date: '2023-02-07'
+        build_date: 2023-02-07
   - name: Ubuntu 20.04 Minimal
     shortname: ubuntu-20.04-minimal
     format: qcow2
@@ -195,7 +195,7 @@ images:
       - version: '20230208'
         url: https://minio.services.osism.tech/openstack-image-manager/ubuntu-20.04-minimal/20230208-ubuntu-20.04-minimal.qcow2
         checksum: sha256:cd27081deb7da3ec210684f39fd3cf5bb894f29ff4e5c7053142412e7885f98a
-        build_date: '2023-02-08'
+        build_date: 2023-02-08
   - name: Ubuntu 22.04
     shortname: ubuntu-22.04
     format: qcow2
@@ -223,7 +223,7 @@ images:
       - version: '20230110'
         url: https://minio.services.osism.tech/openstack-image-manager/ubuntu-22.04/20230110-ubuntu-22.04.qcow2
         checksum: sha256:71657529fc067dbda2537762730904a68905ae1202a30ec00a645828506939df
-        build_date: '2023-01-10'
+        build_date: 2023-01-10
   - name: Ubuntu 22.04 Minimal
     shortname: ubuntu-22.04-minimal
     format: qcow2
@@ -251,4 +251,4 @@ images:
       - version: '20230208'
         url: https://minio.services.osism.tech/openstack-image-manager/ubuntu-22.04-minimal/20230208-ubuntu-22.04-minimal.qcow2
         checksum: sha256:86efe9eb15f328ec5e15f9e9a14f8f9acd77f8c5266c38303af7409e16394f26
-        build_date: '2023-02-08'
+        build_date: 2023-02-08


### PR DESCRIPTION
images.1.versions.0.build_date: '2022-11-18' is not a day. images.1.versions.0.build_date: '2022-11-18' is not a timestamp.

Signed-off-by: Christian Berendt <berendt@osism.tech>