### PR TITLE
Add enable parameter to be able to disable specific images

### DIFF
--- a/etc/images/debian.yml
+++ b/etc/images/debian.yml
@@ -56,6 +56,7 @@ images:
         checksum: sha512:7a7a546b9928f0d375c332a39db2d1af56fce3432b8a5dee0d4f71777efa7463a6b1fc797bcf3b12ca7d8f47d66824abbcbf0a0bdc94be5e90e5a90e8628fae6
         build_date: 2023-01-24
   - name: Debian 12
+    enable: false
     shortname: debian-12
     format: qcow2
     login: debian

--- a/etc/schema.yaml
+++ b/etc/schema.yaml
@@ -3,6 +3,7 @@ images: list(include('image'), min=1)
 
 ---
 image:
+  enable: bool(required=False)
   format: enum('aki', 'ari', 'ami', 'raw', 'iso', 'vhd', 'vdi', 'qcow2', 'vmdk')
   latest_checksum_url: regex('^(http|ftp)s?:\/\/\w+.*', name='valid URL', required=False)
   latest_url: regex('^(http|ftp)s?:\/\/\w+.*', name='valid URL', required=False)

--- a/playbooks/real-world.yml
+++ b/playbooks/real-world.yml
@@ -5,7 +5,7 @@
   roles:
     - role: tox
       vars:
-        tox_extra_args: -- --latest --hide --hypervisor kvm
+        tox_extra_args: -- --latest --hide --hypervisor kvm --force
 
     - role: tox
       vars:

--- a/src/manage.py
+++ b/src/manage.py
@@ -55,6 +55,9 @@ class ImageManager:
         hide: bool = typer.Option(
             False, "--hide", help="Hide images that should be deleted"
         ),
+        force: bool = typer.Option(
+            False, "--force", help="Force upload of disabled images"
+        ),
         delete: bool = typer.Option(False, "--delete", help="Delete outdated images"),
         yes_i_really_know_what_i_do: bool = typer.Option(
             False, "--yes-i-really-know-what-i-do", help="Really delete images"
@@ -132,9 +135,17 @@ class ImageManager:
                     for image in images:
                         if self.CONF.filter:
                             if re.search(self.CONF.filter, image["name"]):
-                                all_images.append(image)
+                                if "enable" in image and (
+                                    (image["enable"])
+                                    or (not image["enable"] and self.CONF.force)
+                                ):
+                                    all_images.append(image)
                         else:
-                            all_images.append(image)
+                            if "enable" in image and (
+                                (image["enable"])
+                                or (not image["enable"] and self.CONF.force)
+                            ):
+                                all_images.append(image)
                 except yaml.YAMLError as exc:
                     logger.error(exc)
         return all_images

--- a/test/unit/test_manage.py
+++ b/test/unit/test_manage.py
@@ -13,6 +13,7 @@ FAKE_YML = '''
 ---
 images:
   - name: Ubuntu 20.04
+    enable: True
     format: qcow2
     login: ubuntu
     min_disk: 8
@@ -34,6 +35,7 @@ images:
 # sample image dict as generated from FAKE_YML
 FAKE_IMAGE_DICT = {
     'name': 'Ubuntu 20.04',
+    'enable': True,
     'format': 'qcow2',
     'login': 'ubuntu',
     'min_disk': 8,


### PR DESCRIPTION
Disabled images can be used via the new --force parameter.

This way it is possible to add new images that should not be deployed by default.