### PR TITLE
Rotate zuul secrets

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -3,16 +3,16 @@
     name: CLOUDS
     data:
       clouds: !encrypted/pkcs1-oaep
-        - qwPpXLe8TvNXdmD+wFgUN4X50QTguUzmSAZzGLltKjYTohyPAwcRl9e4RVG6mA6DCl076
-          IhKlo42cGJxtrmc5MwTvM5o49u+1d1QeFOV49Mgr0BhgwZUKOjV+KR6QI06mb0FT46yV8
-          qGEjICZlayxkNXxGX19UXPLJsqfjPmwic8lCUcorL86xkZ9hy9l+gJGtSSc/s835rVc39
-          HNAECpMYt4CndkWbMLjtpPtzdI21ta2CHxan3qfCByD6Dj3Rmw2tzMDbPTcELMJu0bHVg
-          S+uw+4FsXsvtfAJsx28j03rhMS6nhMIByKoq+0hkicflfoC35IkX4xVDNuCPsS+5/Ejvb
-          LSkoKxwszFhZ35YQ3+7oubjDv3G0rooVE/5dAwbHJXJT7z4ODxu2Iybo7UR6h5G12DxRy
-          A7iv+vxCdVb4NNEgxPWDtQiQt92Efez3CaKV+Jbo0JrKd8jh1JlF+xCDqwcIvuIYAeNkp
-          xaMto+JdxinwrJe6xrEb68q3EpDGiogPJz5dsKn9c+18TebHKzfWqtI+PiuXbsdYFuQmA
-          EaPGzd8z2VJXkH9dre9yN5bKCOnBaoqqpRmrs6Nsx/UukvKW3FxMZM7CsZqL1MTPcQC0n
-          8vLRpo7w76bnCTvlftHEd6v6AXZiLTyRtQTemj3XL7LpOnfF1D1k4fay8+B+aY=
+        - LffnVb8+3O07qmDvnLP2fvzuTwHBg++m2mfw6YJZNAXiFiHzsKEXWGxAknY3Vmzhb2mvY
+          Isp//o5gdwZ/mWRoQjrP1hyTX2INPgruwOwC67YACkAKUqAaaYsuHl9oCVCxKlbcP7k1m
+          416ANG3+l91kC9xuOAEJb1jOqvLsFl9RbKzBgb0QfWcZ5phAherZfaJN0dFz7X4DnTVyy
+          6H7Cglpedw8nN6QG0umFzWABqxW2wPPupLd77dLtXU2m2Wm0NIpdMx2R9+mSdh370I1ue
+          lPuVf/qTSBvPI19YHI3ve9PuAi2Vr4sgLU3uf6+M1KOaHaCMNq/v0qTsPfn4TIPLW1MDZ
+          R1RSOD+Uo4cCfekGsaRhagA2j77B1ERjqdnGI9aoMbVwMVnKzKlAJfPxMPsmCNXtkCDSH
+          Q+w7nP32E7olDYr6ahN/XDSdGJquq/UDyz/J2m/89nj9KXIQRTcr4hjvaQb34l7qk1wH3
+          cZ5nX/UmBYd5+e8y48jKKAHZMV81PGbyE9Az+MKJLMaKO4DT5P4kEGMEPmGEveTzcG2nh
+          yAU/TbgmxtRUmOr9YZUoXr1bT5BPd3h+QLpQBG2OTBhNH7LNT3IJ6Ce1Tjbh7nzupDXEE
+          V4+C8M1SyCIJsoudTUSuqFRqOrN4cNVVEgHVo8JOhp0q/rv15wYuDzM42lMUXw=
 
 - job:
     name: integration-test


### PR DESCRIPTION
No security breach, but rather a loss of the zuul server database was the reason for the rotation.

Signed-off-by: Tim Beermann <beermann@osism.tech>
