### PR TITLE
Add gz file extension

### DIFF
--- a/src/mirror.py
+++ b/src/mirror.py
@@ -70,7 +70,7 @@ def main(
             dirname = "%s/%s" % (image['shortname'], version['version'])
             filename, fileextension = os.path.splitext(os.path.basename(path.path))
 
-            if fileextension not in ['.bz2', '.zip', '.xz']:
+            if fileextension not in ['.bz2', '.zip', '.xz', '.gz']:
                 filename += fileextension
 
             logging.debug("dirname: %s" % dirname)
@@ -89,7 +89,7 @@ def main(
                         shutil.copyfileobj(response.raw, fp)
                     del response
 
-                    if fileextension in ['.bz2', '.zip', '.xz']:
+                    if fileextension in ['.bz2', '.zip', '.xz', '.gz']:
                         logging.info("Decompressing '%s'" % os.path.basename(path.path))
                         patoolib.extract_archive(os.path.basename(path.path), outdir='.')
                         os.remove(os.path.basename(path.path))

--- a/src/update.py
+++ b/src/update.py
@@ -38,7 +38,7 @@ def mirror_image(image, latest_url, CONF):
     dirname = image["shortname"]
     filename, fileextension = os.path.splitext(os.path.basename(path.path))
 
-    if fileextension not in [".bz2", ".zip", ".xz"]:
+    if fileextension not in [".bz2", ".zip", ".xz", ".gz"]:
         filename += fileextension
 
     shortname = image["shortname"]
@@ -57,7 +57,7 @@ def mirror_image(image, latest_url, CONF):
             shutil.copyfileobj(response.raw, fp)
         del response
 
-        if fileextension in [".bz2", ".zip", ".xz"]:
+        if fileextension in [".bz2", ".zip", ".xz", ".gz"]:
             logger.info("Decompressing '%s'" % os.path.basename(path.path))
             patoolib.extract_archive(os.path.basename(path.path), outdir=".")
             os.remove(os.path.basename(path.path))


### PR DESCRIPTION
Talos image introduced a .tar.gz file type.
Added gz as a fileextension canidate that should be decompressed.

Signed-off-by: Tim Beermann <beermann@osism.tech>
