### PR TITLE
Allow to keep undefined versions of defined images

### DIFF
--- a/playbooks/real-world.yml
+++ b/playbooks/real-world.yml
@@ -5,7 +5,7 @@
   roles:
     - role: tox
       vars:
-        tox_extra_args: -- --latest --hide --hypervisor kvm --force
+        tox_extra_args: -- --latest --hide --hypervisor kvm --force --keep
 
     - role: tox
       vars:


### PR DESCRIPTION
With the parameter --keep it is possible to keep versions of defined images that are not longer defined itself.

Processing image 'Garden Linux 576.12'
Skipping image 'Garden Linux 576.12' (only importing the latest version from type multi) Processing image 'Garden Linux 934.8'
Processing unmanaged image 'Garden Linux 934.6'
The image 'Garden Linux 934.6' is not deleted because undefined versions of defined images are kept