### PR TITLE
Disable el8 images by default

### DIFF
--- a/etc/images/almalinux.yml
+++ b/etc/images/almalinux.yml
@@ -1,7 +1,7 @@
 ---
 images:
   - name: AlmaLinux 8
-    enable: true
+    enable: false
     shortname: almalinux-8
     format: qcow2
     login: almalinux

--- a/etc/images/centos.yml
+++ b/etc/images/centos.yml
@@ -32,7 +32,7 @@ images:
         checksum: sha256:e38bab0475cc6d004d2e17015969c659e5a308111851b0e2715e84646035bdd3
         build_date: 2020-11-12
   - name: CentOS Stream 8
-    enable: true
+    enable: false
     shortname: centos-stream-8
     format: qcow2
     login: centos

--- a/etc/images/rockylinux.yml
+++ b/etc/images/rockylinux.yml
@@ -1,7 +1,7 @@
 ---
 images:
   - name: Rocky 8
-    enable: true
+    enable: false
     shortname: rocky-8
     format: qcow2
     login: rocky


### PR DESCRIPTION
As discussed in the SCS project, we no longer want to use EL8 images by default.