### PR TITLE
Fix mypy typing problems and enable mypy zuul job

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -37,15 +37,17 @@
       jobs:
         - flake8
         - hadolint
-        - markdownlint
         - integration-test
+        - markdownlint
+        - mypy
         - yamllint
     gate:
       jobs:
         - flake8
         - hadolint
-        - markdownlint
         - integration-test
+        - markdownlint
+        - mypy
         - yamllint
     post:
       jobs:
@@ -54,6 +56,7 @@
       jobs:
         - flake8
         - hadolint
-        - markdownlint
         - integration-test
+        - markdownlint
+        - mypy
         - yamllint

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+exclude = doc

--- a/openstack_image_manager/manage.py
+++ b/openstack_image_manager/manage.py
@@ -6,6 +6,7 @@ import os
 import re
 import sys
 import typer
+from typing import Dict, Set
 import yamale
 
 from datetime import datetime
@@ -271,7 +272,7 @@ class ImageManager:
             "versions",
             "visibility",
         ]
-        managed_images = set()
+        managed_images: Set[str] = set()
 
         for image in images:
             for required_key in REQUIRED_KEYS:
@@ -449,7 +450,7 @@ class ImageManager:
         """
         cloud_images = self.get_images()
 
-        existing_images = set()
+        existing_images: Set[str] = set()
         imported_image = None
         previous_image = None
         upstream_checksum = ""
@@ -865,7 +866,7 @@ class ImageManager:
                 [x for x in cloud_images if x not in managed_images], reverse=True
             )
 
-        counter = {}
+        counter: Dict[str, int] = {}
 
         for image in unmanaged_images:
             logger.info(f"Processing image '{image}' (removal candidate)")

--- a/openstack_image_manager/mirror.py
+++ b/openstack_image_manager/mirror.py
@@ -52,8 +52,8 @@ def main(
     for file in onlyfiles:
         with open(join(CONF.images, file)) as fp:
             data = yaml.load(fp, Loader=yaml.SafeLoader)
-            images = data.get("images")
-            for image in images:
+            imgs = data.get("images")
+            for image in imgs:
                 all_images.append(image)
 
     client = Minio(

--- a/openstack_image_manager/table.py
+++ b/openstack_image_manager/table.py
@@ -27,8 +27,8 @@ def main(
     for file in onlyfiles:
         with open(join(CONF.images, file)) as fp:
             data = yaml.load(fp, Loader=yaml.SafeLoader)
-            images = data.get("images")
-            for image in images:
+            imgs = data.get("images")
+            for image in imgs:
                 all_images.append(image)
 
     data = []

--- a/test/unit/test_manage.py
+++ b/test/unit/test_manage.py
@@ -3,6 +3,7 @@ from munch import Munch
 from unittest import TestCase, mock
 from openstack.image.v2.image import Image
 from openstack.image.v2._proxy import Proxy
+from typing import Any, Dict
 
 from openstack_image_manager import manage
 
@@ -33,7 +34,7 @@ images:
 '''
 
 # sample image dict as generated from FAKE_YML
-FAKE_IMAGE_DICT = {
+FAKE_IMAGE_DICT : Dict[str, Any] = {
     'name': 'Ubuntu 20.04',
     'enable': True,
     'format': 'qcow2',


### PR DESCRIPTION
This commit adds type hints where necessary and
renames a local variable from 'images' to 'imgs',
because it shared the name with a function parameter,
which threw off automatic type checking.

Also added the mypy.ini to exclude the doc/ folder
for now.