### PR TITLE
Removing --validate typer/command-line option from image-manager

### DIFF
--- a/doc/getting_started.md
+++ b/doc/getting_started.md
@@ -42,8 +42,6 @@ As you can do many things with this manager here a list with possible commands:
 |                                 |Defines the scope where the image is (un)shared.|
 |`--check`                        |Check your OpenStack images metadata against the SCS standards.|
 |                                 |Gives you a detailed list of missing metadata.|
-|`--validate`                     |Validate your image config files metadata against the SCS standard.|
-|                                 |Gives you a detailed list of invalid metadata.|
 
 Main command. Works through the image config files and applies the changes to your OpenStack as desired.
 Commands prefixed with **--share** make an image available (or unavailable). This can happen on a single project or on all projects of a domain.

--- a/openstack_image_manager/manage.py
+++ b/openstack_image_manager/manage.py
@@ -91,11 +91,6 @@ class ImageManager:
             "--check",
             help="Check the local image definitions against the SCS Image Metadata Standard",
         ),
-        validate: bool = typer.Option(
-            False,
-            "--validate",
-            help="Validate the image metadata against the SCS Image Metadata Standard",
-        ),
     ):
         self.CONF = Munch.fromDict(locals())
         self.CONF.pop("self")  # remove the self object from CONF
@@ -208,13 +203,8 @@ class ImageManager:
             "yes-i-really-know-what-i-do = %s" % self.CONF.yes_i_really_know_what_i_do
         )
 
-        # validate metadata of existing images
-        if self.CONF.validate:
-            self.create_connection()
-            self.check_image_metadata()
-
         # check local image definitions with yamale
-        elif self.CONF.check:
+        if self.CONF.check:
             self.validate_yaml_schema()
 
         # share image (previously share.py)
@@ -1003,192 +993,6 @@ class ImageManager:
                 logger.info("Setting visibility of '%s' to 'community'" % image)
                 self.conn.image.update_image(cloud_image.id, visibility="community")
         return unmanaged_images
-
-    def check_image_metadata(self):
-        """
-        Retrieve metadata from managed images and check for compliance with SCS specifications:
-        -> https://github.com/SovereignCloudStack/Docs/blob/main/Design-Docs/Image-Properties-Spec.md
-
-        code adopted from https://github.com/SovereignCloudStack/Docs/blob/main/Design-Docs/tools/image-md-check.py
-        """
-        cloud_images = self.get_images()
-
-        mand_images = ["Ubuntu 22.04", "Ubuntu 20.04", "Debian 11"]
-        rec1_images = ["CentOS 8", "Rocky 8", "AlmaLinux 8", "Debian 10", "Fedora 36"]
-        rec2_images = [
-            "SLES 15SP4",
-            "RHEL 9",
-            "RHEL 8",
-            "Windows Server 2022",
-            "Windows Server 2019",
-        ]
-        # sugg_images = ["openSUSE Leap 15.4", "Cirros 0.5.2", "Alpine", "Arch"]    # Ignore for now
-
-        # properties inside of the main image dict
-        image_properties = {
-            "os_distro": {"mandatory": True, "values": None},
-            "os_version": {"mandatory": True, "values": None},
-            "architecture": {
-                "mandatory": True,
-                "values": ["x86_64", "aarch64", "risc-v"],
-            },
-            "hypervisor_type": {
-                "mandatory": True,
-                "values": ["qemu", "kvm", "xen", "hyper-v", "esxi", None],
-            },
-            "hw_rng_model": {"mandatory": False, "values": ["virtio", None]},
-            "hw_disk_bus": {"mandatory": True, "values": ["virtio", "scsi", None]},
-            "hash_algo": {"mandatory": False, "values": ["sha256", "sha512"]},
-        }
-
-        # properties inside of the image.properties dict
-        custom_properties = {
-            "image_build_date": {"mandatory": True, "values": None},
-            "patchlevel": {"mandatory": False, "values": None},
-            "image_original_user": {"mandatory": True, "values": None},
-            "image_source": {"mandatory": True, "values": None},
-            "image_description": {"mandatory": True, "values": None},
-            "replace_frequency": {
-                "mandatory": True,
-                "values": [
-                    "yearly",
-                    "quarterly",
-                    "monthly",
-                    "weekly",
-                    "daily",
-                    "critical_bug",
-                    "never",
-                ],
-            },
-            "provided_until": {"mandatory": True, "values": None},
-            "uuid_validity": {"mandatory": True, "values": None},
-            "hotfix_hours": {"mandatory": False, "values": None},
-        }
-
-        for image_name in cloud_images.keys():
-            try:
-                image = self.conn.image.find_image(image_name)
-            except DuplicateResource as exc:
-                logger.error("Duplicate name: %s\n%s" % (image_name, str(exc)))
-                self.exit_with_error = True
-                continue
-            if not image:
-                logger.error("Image %s not found" % image_name)
-                self.exit_with_error = True
-                continue
-            if image.status not in ["active", "deactivated"]:
-                logger.error("Image %s is in %s state" % (image_name, image.status))
-                self.exit_with_error = True
-                continue
-
-            for prop in image_properties:
-                if prop in image:
-                    values = image_properties[prop]["values"]
-                    if values and not image[prop] in values:
-                        logger.error(
-                            "Image %s: Value %s not allowed for property %s"
-                            % (image.name, image[prop], prop)
-                        )
-                        self.exit_with_error = True
-                elif image_properties[prop]["mandatory"]:
-                    logger.error(
-                        "Image %s: Missing mandatory image property %s"
-                        % (image.name, prop)
-                    )
-                    self.exit_with_error = True
-                else:
-                    logger.info(
-                        "Image %s: Missing optional image property %s"
-                        % (image.name, prop)
-                    )
-
-            if (
-                "hw_rng_model" in image
-                and image.hw_rng_model == "scsi"
-                and "hw_disk_bus" in image
-                and image.hw_disk_bus == "scsi"
-            ):
-                if "hw_scsi_model" not in image:
-                    logger.info(
-                        "Image %s: property hw_scsi_model is recommended when using 'scsi' for "
-                        "hw_rng_model and hw_disk_bus" % image.name
-                    )
-
-            for prop in custom_properties:
-                if prop in image.properties:
-                    values = custom_properties[prop]["values"]
-                    if values and not image.properties[prop] in values:
-                        logger.error(
-                            "Image %s: Value %s not allowed for property %s"
-                            % (image.name, image.properties[prop], prop)
-                        )
-                        self.exit_with_error = True
-                elif custom_properties[prop]["mandatory"]:
-                    logger.error(
-                        "Image %s: Missing mandatory custom property %s"
-                        % (image.name, prop)
-                    )
-                    self.exit_with_error = True
-                else:
-                    logger.info(
-                        "Image %s: Missing optional custom property %s"
-                        % (image.name, prop)
-                    )
-
-            if "image_build_date" in image.properties:
-                try:
-                    time.strptime(image.properties["image_build_date"][:10], "%Y-%m-%d")
-                except Exception:
-                    logger.error(
-                        "Image %s: invalid value for image_build_date %s"
-                        % (image.name, image.properties["build_date"])
-                    )
-                    self.exit_with_error = True
-
-            if "image_source" in image.properties:
-                if not re.match(
-                    r"^(http|ftp)s?://\w*.*|^file:\w+.*", image.properties["image_source"]
-                ):
-                    logger.error(
-                        "Image %s: image_source is not a valid URL" % image.name
-                    )
-                    self.exit_with_error = True
-
-            if "hotfix_hours" in image.properties:
-                if (
-                    type(image.properties["hotfix_hours"]) == str
-                    and not image.properties["hotfix_hours"].isdigit()
-                ):
-                    logger.error(
-                        "Image %s: custom property hotfix_hours is not numeric"
-                        % image.name
-                    )
-
-            rec_image_name = "%s %s" % (image.os_distro, image.os_version)
-            if not re.match(f"^{rec_image_name}", image.name, re.IGNORECASE):
-                logger.info(
-                    "Image %s: Name does not start with recommended name %s"
-                    % (image.name, rec_image_name)
-                )
-
-            rec_tag = "os:%s" % image.os_distro
-            if rec_tag not in image.tags:
-                logger.info(
-                    "Image %s: Missing recommended tag %s" % (image.name, rec_tag)
-                )
-            if not any(tag.startswith("managed_by_") for tag in image.tags):
-                logger.info(
-                    "Image %s: Missing recommended tag managed_by_" % image.name
-                )
-
-        # check for image completeness
-        for image in mand_images:
-            if image not in cloud_images:
-                logger.info("Mandatory image %s is missing" % image)
-        for image in (*rec1_images, *rec2_images):
-            if image not in cloud_images:
-                logger.info("Recommended image %s is missing" % image)
-        # Ignore sugg_images for now
 
     def validate_yaml_schema(self):
         """Validate all image.yaml files against the SCS Metadata spec"""

--- a/playbooks/real-world.yml
+++ b/playbooks/real-world.yml
@@ -18,7 +18,3 @@
     - role: tox
       vars:
         tox_extra_args: -- --hide --hypervisor kvm --force --keep --delete --yes-i-really-know-what-i-do
-
-    - role: tox
-      vars:
-        tox_extra_args: -- --validate

--- a/test/integration/test_manage_api.py
+++ b/test/integration/test_manage_api.py
@@ -27,8 +27,7 @@ class TestManageAPI(TestCase):
             filter='',
             keep=False,
             force=False,
-            hypervisor=None,
-            validate=False
+            hypervisor=None
         )
         self.web_image = self.sot.read_image_files()[0]
         self.assertEqual(self.web_image['name'], 'Cirros_test')

--- a/test/unit/test_manage.py
+++ b/test/unit/test_manage.py
@@ -125,8 +125,7 @@ class TestManage(TestCase):
             share_type='project',
             filter='',
             check=False,
-            validate=False,
-            hypervisor=None,
+            hypervisor=None
         )
 
         # we can also mimick an openstack connection object with a Munch
@@ -347,15 +346,14 @@ class TestManage(TestCase):
     @mock.patch('openstack_image_manager.manage.ImageManager.unshare_image_with_project')
     @mock.patch('openstack_image_manager.manage.ImageManager.share_image_with_project')
     @mock.patch('openstack_image_manager.manage.ImageManager.validate_yaml_schema')
-    @mock.patch('openstack_image_manager.manage.ImageManager.check_image_metadata')
     @mock.patch('openstack_image_manager.manage.ImageManager.manage_outdated_images')
     @mock.patch('openstack_image_manager.manage.ImageManager.process_images')
     @mock.patch('openstack_image_manager.manage.ImageManager.get_images')
     @mock.patch('openstack_image_manager.manage.ImageManager.read_image_files')
     @mock.patch('openstack_image_manager.manage.openstack.connect')
     def test_main(self, mock_connect, mock_read_image_files, mock_get_images,
-                  mock_process_images, mock_manage_outdated, mock_check_metadata,
-                  mock_validate_yaml, mock_share_image, mock_unshare_image):
+                  mock_process_images, mock_manage_outdated, mock_validate_yaml,
+                  mock_share_image, mock_unshare_image):
         ''' test manage.ImageManager.main() '''
         mock_read_image_files.return_value = [self.fake_image_dict]
         mock_process_images.return_value = set()
@@ -366,7 +364,6 @@ class TestManage(TestCase):
         mock_read_image_files.assert_called_once()
         mock_process_images.assert_called_once_with([self.fake_image_dict])
         mock_manage_outdated.assert_called_once_with(set())
-        mock_check_metadata.assert_not_called()
         mock_validate_yaml.assert_not_called()
         mock_share_image.assert_not_called()
         mock_unshare_image.assert_not_called()
@@ -376,31 +373,6 @@ class TestManage(TestCase):
         mock_get_images.reset_mock()
         mock_process_images.reset_mock()
         mock_manage_outdated.reset_mock()
-        mock_check_metadata.reset_mock()
-        mock_validate_yaml.reset_mock()
-        mock_share_image.reset_mock()
-        mock_unshare_image.reset_mock()
-
-        # test with dry_run = True and validate = True
-        self.sot.CONF.dry_run = True
-        self.sot.CONF.validate = True
-
-        self.sot.main()
-        mock_read_image_files.assert_not_called()
-        mock_get_images.assert_not_called()
-        mock_process_images.assert_not_called()
-        mock_manage_outdated.assert_not_called()
-        mock_check_metadata.assert_called_once()
-        mock_validate_yaml.assert_not_called()
-        mock_share_image.assert_not_called()
-        mock_unshare_image.assert_not_called()
-
-        # reset
-        mock_read_image_files.reset_mock()
-        mock_get_images.reset_mock()
-        mock_process_images.reset_mock()
-        mock_manage_outdated.reset_mock()
-        mock_check_metadata.reset_mock()
         mock_validate_yaml.reset_mock()
         mock_share_image.reset_mock()
         mock_unshare_image.reset_mock()
@@ -409,14 +381,12 @@ class TestManage(TestCase):
         self.sot.CONF.check = True
 
         self.sot.CONF.dry_run = False
-        self.sot.CONF.validate = False
 
         self.sot.main()
         mock_read_image_files.assert_not_called()
         mock_get_images.assert_not_called()
         mock_process_images.assert_not_called()
         mock_manage_outdated.assert_not_called()
-        mock_check_metadata.assert_not_called()
         mock_validate_yaml.assert_called_once()
         mock_share_image.assert_not_called()
         mock_unshare_image.assert_not_called()


### PR DESCRIPTION
This change will remove the --validate option from the image-manager and its unit tests.

fixes #441