### PR TITLE
Add yml flag to skip deletion of oldest image for selected images

### DIFF
--- a/etc/schema.yaml
+++ b/etc/schema.yaml
@@ -12,6 +12,7 @@ image:
   min_disk: int(min=0)
   min_ram: int(min=0)
   multi: bool()
+  keep: bool(required=False)
   name: str()
   password: str(required=False)
   shortname: str(required=False)

--- a/openstack_image_manager/manage.py
+++ b/openstack_image_manager/manage.py
@@ -1055,8 +1055,11 @@ class ImageManager:
                             cloud_image.id, visibility="community"
                         )
 
-                        logger.info("Deleting %s" % image)
-                        self.conn.image.delete_image(cloud_image.id)
+                        if "keep" not in image_definition or not image_definition["keep"]:
+                            logger.info("Deleting %s" % image)
+                            self.conn.image.delete_image(cloud_image.id)
+                        else:
+                            logger.info("Image '%s' will not be deleted, because 'keep' flag is True" % image)
                     except Exception as e:
                         logger.info(
                             "%s is still in use and cannot be deleted\n %s" % (image, e)


### PR DESCRIPTION
Previously, old images were rotated and finally deleted after a certain number of newer images were released.
This commit adds a flag for the yml definition to stop automatic deletion.

- [x] Add unit test

Fixes #342 