### PR TITLE
Update example command in quickstart guide

### DIFF
--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -61,6 +61,6 @@ Only run it against config files where the name matches _Cirr_.
 Also provide the location of your image files (_~/images/_).
 
 ```bash
-openstack-image-manager --cloud my-cloud --name "*Cirr*" --images ~/images/
+openstack-image-manager --cloud my-cloud --filter ".*Cirr.*" --images ~/images/
 ```
 


### PR DESCRIPTION
Currently the quickstart guide references a `--name` flag in the example command which is not an implemented flag (anymore?). I've replaced it with the equivalent `--filter` usage instead.