### PR TITLE
Preserve original URL when mirroring image

### DIFF
--- a/openstack_image_manager/manage.py
+++ b/openstack_image_manager/manage.py
@@ -281,6 +281,10 @@ class ImageManager:
                 versions = dict()
                 for version in image["versions"]:
                     versions[str(version["version"])] = {"url": version["url"]}
+                    if "mirror_url" in version:
+                        versions[version["version"]]["mirror_url"] = version[
+                            "mirror_url"
+                        ]
                     if "visibility" in version:
                         versions[version["version"]]["visibility"] = version[
                             "visibility"
@@ -580,7 +584,9 @@ class ImageManager:
                 and len(sorted_versions) > 1
                 and version != sorted_versions[-1]
             ):
-                url = versions[version]["url"]
+                # use `mirror_url` for download if given, else fall back to `url`
+                # in any case, `url` will be used to set `image_source` property
+                url = versions[version].get("mirror_url", versions[version]["url"])
                 parsed_url = urllib.parse.urlparse(url)
                 if parsed_url.scheme == "file":
                     file_path = parsed_url.path

--- a/openstack_image_manager/update.py
+++ b/openstack_image_manager/update.py
@@ -190,7 +190,8 @@ def update_image(image, CONF):
         minio_bucket = str(CONF.minio_bucket)
         new_url = f"https://{minio_server}/{minio_bucket}/{shortname}/{new_version}-{shortname}.{format}"
         logger.info(f"New URL is {new_url}")
-        image["versions"][0]["url"] = new_url
+        image["versions"][0]["mirror_url"] = new_url
+        image["versions"][0]["url"] = latest_url
 
         mirror_image(image, latest_url, CONF)
         del image["versions"][0]["source"]


### PR DESCRIPTION
Preserve original URL when mirroring image in
update script (resolves #634).

Developed-by: Matthias Büchse <matthias.buechse@cloudandheat.com>
Submitted-by: Sven Kieske <kieske@osism.tech>

Signed-off-by: Matthias Büchse <matthias.buechse@cloudandheat.com>
Signed-off-by: Sven Kieske <kieske@osism.tech>