### PR TITLE
Unify the build_date of all image references

### DIFF
--- a/etc/images/almalinux.yml
+++ b/etc/images/almalinux.yml
@@ -30,7 +30,7 @@ images:
         url: 
           https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/openstack-images/almalinux-8/20230524-almalinux-8.qcow2
         checksum: sha256:c0ad09255d91288dac590d99c95197d83a2846f1bcbec3f4222fb04265a2a4d7
-        build_date: '2023-05-24'
+        build_date: 2023-05-24
   - name: AlmaLinux 9
     enable: true
     shortname: almalinux-9
@@ -61,4 +61,4 @@ images:
         url: 
           https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/openstack-images/almalinux-9/20230513-almalinux-9.qcow2
         checksum: sha256:207d885ca8140e3106098e946cfc04088b0e21f50d24815051520d452eae0a50
-        build_date: '2023-05-13'
+        build_date: 2023-05-13

--- a/etc/images/centos.yml
+++ b/etc/images/centos.yml
@@ -30,7 +30,7 @@ images:
         url: 
           https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/openstack-images/centos-7/20221112-centos-7.qcow2
         checksum: sha256:284aab2b23d91318f169ff464bce4d53404a15a0618ceb34562838c59af4adea
-        build_date: '2022-11-12'
+        build_date: 2022-11-12
   - name: CentOS Stream 8
     enable: true
     shortname: centos-stream-8
@@ -61,7 +61,7 @@ images:
         url: 
           https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/openstack-images/centos-stream-8/20230826-centos-stream-8.qcow2
         checksum: sha256:3d0b45bacb0355d7f0542d302a7a71146b425f41b513782b4dc554daffe72e9e
-        build_date: '2023-08-26'
+        build_date: 2023-08-26
   - name: CentOS Stream 9
     enable: true
     shortname: centos-stream-9
@@ -92,4 +92,4 @@ images:
         url: 
           https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/openstack-images/centos-stream-9/20230821-centos-stream-9.qcow2
         checksum: sha256:ce7828ea362f4c63d5a73567ee4adce11248b017473ac3bdfa1c155af8796fe5
-        build_date: '2023-08-21'
+        build_date: 2023-08-21

--- a/etc/images/clearlinux.yml
+++ b/etc/images/clearlinux.yml
@@ -27,4 +27,4 @@ images:
         url: https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/openstack-images/clearlinux/38700/clear-38700-cloudguest.img
         source: https://cdn.download.clearlinux.org/releases/38700/clear/clear-38700-cloudguest.img.xz
         checksum: "sha256:554f2e9f1c5cd3caa7ca9043e9379ab7bac36f8004ae6023f2fb642b80ace173"
-        build_date: '2023-03-31'
+        build_date: 2023-03-31

--- a/etc/images/debian.yml
+++ b/etc/images/debian.yml
@@ -31,7 +31,7 @@ images:
           https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/openstack-images/debian-10/20230802-debian-10.qcow2
         checksum: 
           sha512:a11252378a9573052b48fcec8cb0e5d6ab11338e81e960442eb8a9bf4504d8e25f5c2cd893c010f63ef99201b96e4f9cae7fce6c8f8132e18f1a561b9afd8eb3
-        build_date: '2023-08-02'
+        build_date: 2023-08-02
   - name: Debian 11
     enable: true
     shortname: debian-11
@@ -62,7 +62,7 @@ images:
           https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/openstack-images/debian-11/20230802-debian-11.qcow2
         checksum: 
           sha512:f16512174452ea49e34d302e86bb11b6f821013dde583bf703550998e87819f98c6e411d7737bd53f16c73007f1c039218f9cd40421ec3a6b5b1fe38044018c0
-        build_date: '2023-08-02'
+        build_date: 2023-08-02
   - name: Debian 12
     enable: true
     shortname: debian-12
@@ -88,7 +88,7 @@ images:
     latest_url: 
       https://cdimage.debian.org/cdimage/cloud/bookworm/daily/latest/debian-12-genericcloud-amd64-daily.qcow2
     versions:
-      - build_date: '2023-08-26'
+      - build_date: 2023-08-26
         checksum: 
           sha512:b9b01448d1572326622e7e5bcf060b995bf5c66326e826f0149c21807cfbda4000224aeb2f43a1991ab486c05d0e184e13de3dd4e0be48611626377fb10d9263
         url: 

--- a/etc/images/fedora.yml
+++ b/etc/images/fedora.yml
@@ -28,4 +28,4 @@ images:
         url: https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/openstack-images/fedora-37/20230402/Fedora-Cloud-Base-37-1.7.x86_64.qcow2
         source: https://download.fedoraproject.org/pub/fedora/linux/releases/37/Cloud/x86_64/images/Fedora-Cloud-Base-37-1.7.x86_64.qcow2
         checksum: "sha256:b5b9bec91eee65489a5745f6ee620573b23337cbb1eb4501ce200b157a01f3a0"
-        build_date: '2022-11-05'
+        build_date: 2022-11-05

--- a/etc/images/kubernetes.yml
+++ b/etc/images/kubernetes.yml
@@ -25,16 +25,16 @@ images:
       - version: '1.24.15'
         url: https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/openstack-k8s-capi-images/ubuntu-2204-kube-v1.24/ubuntu-2204-kube-v1.24.15.qcow2
         checksum: "sha256:12fbfead6400fae2fac20b8fae130e23afc351c44ad120deee2318b4bc7b2e59"
-        build_date: '2023-06-15'
+        build_date: 2023-06-15
       - version: '1.25.11'
         url: https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/openstack-k8s-capi-images/ubuntu-2204-kube-v1.25/ubuntu-2204-kube-v1.25.11.qcow2
         checksum: "sha256:7870a6c7c1761c572c070ca7b776b39344d8d2fd0dca28718fff433e9dca1a8f"
-        build_date: '2023-06-21'
+        build_date: 2023-06-21
       - version: '1.26.6'
         url: https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/openstack-k8s-capi-images/ubuntu-2204-kube-v1.26/ubuntu-2204-kube-v1.26.6.qcow2
         checksum: "sha256:0243eeee8a55ed9d9f920d4b168ec548541dc2504c996d58a20be5f6d6518409"
-        build_date: '2023-06-21'
+        build_date: 2023-06-21
       - version: '1.27.3'
         url: https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/openstack-k8s-capi-images/ubuntu-2204-kube-v1.27/ubuntu-2204-kube-v1.27.3.qcow2
         checksum: "sha256:857bbb11f29faba71f9f6dc1c44ed657507e422b42f589e1d96da2711c41d5bf"
-        build_date: '2023-06-21'
+        build_date: 2023-06-21

--- a/etc/images/octavia.yml
+++ b/etc/images/octavia.yml
@@ -26,4 +26,4 @@ images:
       - version: 'ZED-2023-05-05'
         url: https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/openstack-octavia-amphora-image/octavia-amphora-haproxy-zed.qcow2
         checksum: "sha256:f0ec47f052e9549b88b3ae86c805ab05036b2a711761b3e2595cb6325311588d"
-        build_date: '2023-05-05'
+        build_date: 2023-05-05

--- a/etc/images/rockylinux.yml
+++ b/etc/images/rockylinux.yml
@@ -31,7 +31,7 @@ images:
         url: 
           https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/openstack-images/rocky-8/20230518-rocky-8.qcow2
         checksum: sha256:086bf68f84c974cfcf533741c5be8752270df681a38f20423cf24b851d5edf77
-        build_date: '2023-05-18'
+        build_date: 2023-05-18
   - name: Rocky 9
     enable: true
     shortname: rocky-9
@@ -63,4 +63,4 @@ images:
         url: 
           https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/openstack-images/rocky-9/20230515-rocky-9.qcow2
         checksum: sha256:50510f98abe1b20a548102a05a9be83153b0bf634fc502d5c8d1f508f6de1430
-        build_date: '2023-05-15'
+        build_date: 2023-05-15

--- a/etc/images/talos.yml
+++ b/etc/images/talos.yml
@@ -27,9 +27,9 @@ images:
         url: https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/openstack-images/talos/1.3.6/disk.raw
         source: https://github.com/siderolabs/talos/releases/download/v1.3.6/openstack-amd64.tar.gz
         checksum: "sha256:1db0cfd9bd9c3d3165911ab89ef05dad1d590cc442fb0702564cfe737b3f3dbd"
-        build_date: '2023-03-14'
+        build_date: 2023-03-14
       - version: '1.4.5'
         url: https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/openstack-images/talos/1.4.5/disk.raw
         source: https://github.com/siderolabs/talos/releases/download/v1.4.5/openstack-amd64.tar.gz
         checksum: "sha256:fc7dc71a6acece93196c8bace15139469b7bfbe4fa7d001336da0fdda9b437c9"
-        build_date: '2023-05-30'
+        build_date: 2023-05-30

--- a/etc/images/ubuntu.yml
+++ b/etc/images/ubuntu.yml
@@ -122,7 +122,7 @@ images:
         url: 
           https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/openstack-images/ubuntu-18.04/20230607-ubuntu-18.04.qcow2
         checksum: sha256:8dd2e6b5e5aad20c3f836123b300cba9861249408cbb07c359145a65d6bab6b6
-        build_date: '2023-06-07'
+        build_date: 2023-06-07
   - name: Ubuntu 18.04 Minimal
     enable: false
     shortname: ubuntu-18.04-minimal
@@ -153,7 +153,7 @@ images:
         url: 
           https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/openstack-images/ubuntu-18.04-minimal/20230602-ubuntu-18.04-minimal.qcow2
         checksum: sha256:2d9755669c499e88d51da0638cd20e0983a248828e2153906c013bea0ee2f45a
-        build_date: '2023-06-02'
+        build_date: 2023-06-02
   - name: Ubuntu 20.04
     enable: true
     shortname: ubuntu-20.04
@@ -183,7 +183,7 @@ images:
         url: 
           https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/openstack-images/ubuntu-20.04/20230823-ubuntu-20.04.qcow2
         checksum: sha256:ecfb2e07fce2a273e845ca328b96b64390a0bf0efad70fd1d57a0ebbc0549717
-        build_date: '2023-08-23'
+        build_date: 2023-08-23
   - name: Ubuntu 20.04 Minimal
     enable: true
     shortname: ubuntu-20.04-minimal
@@ -214,7 +214,7 @@ images:
         url: 
           https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/openstack-images/ubuntu-20.04-minimal/20230811-ubuntu-20.04-minimal.qcow2
         checksum: sha256:95536fe95112fff650012867afbf36d31f61ec06dea4269f8133bd6a1596bf95
-        build_date: '2023-08-11'
+        build_date: 2023-08-11
   - name: Ubuntu 22.04
     enable: true
     shortname: ubuntu-22.04
@@ -244,7 +244,7 @@ images:
         url: 
           https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/openstack-images/ubuntu-22.04/20230823-ubuntu-22.04.qcow2
         checksum: sha256:a7845be05e3a5c9e031be35d27ecb6f4c1cdab8df89475cd1943d57ff94294c9
-        build_date: '2023-08-23'
+        build_date: 2023-08-23
   - name: Ubuntu 22.04 Minimal
     enable: true
     shortname: ubuntu-22.04-minimal
@@ -275,4 +275,4 @@ images:
         url: 
           https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/openstack-images/ubuntu-22.04-minimal/20230815-ubuntu-22.04-minimal.qcow2
         checksum: sha256:72ca6ba4f8b7305479ed32ed79890a52aec4f0629762286dbc9a5e5b3997489c
-        build_date: '2023-08-15'
+        build_date: 2023-08-15

--- a/etc/schema.yaml
+++ b/etc/schema.yaml
@@ -39,7 +39,7 @@ meta:
 
 ---
 versions:
-  build_date: any(day(), timestamp(), str())
+  build_date: any(day(), timestamp())
   checksum: regex('\w+:([a-f0-9]{32}|[a-f0-9]{40}|[a-f0-9]{64}|[a-f0-9]{128})$', name='valid checksum', required=False)
   checksums_url: regex('^(http|ftp)s?:\/\/\w+.*', name='valid URL', required=False)
   hidden: bool(required=False)

--- a/openstack_image_manager/update.py
+++ b/openstack_image_manager/update.py
@@ -177,7 +177,7 @@ def update_image(image, minio_server, minio_bucket, minio_access_key, minio_secr
 
         new_build_date = dt.strftime("%Y-%m-%d")
         logger.info(f"New build date is {new_build_date}")
-        image["versions"][0]["build_date"] = new_build_date
+        image["versions"][0]["build_date"] = dt.date()
 
         logger.info(f"New checksum is {current_checksum}")
         image["versions"][0]["checksum"] = current_checksum

--- a/test/unit/test_manage.py
+++ b/test/unit/test_manage.py
@@ -5,7 +5,7 @@ from unittest import TestCase, mock
 from openstack.image.v2.image import Image
 from openstack.image.v2._proxy import Proxy
 from typing import Any, Dict
-
+from datetime import date
 from openstack_image_manager import manage
 
 logger.remove()   # disable all logging from manage.py
@@ -31,7 +31,7 @@ images:
     tags: []
     versions:
       - version: '1'
-        build_date: '2021-01-21'
+        build_date: 2021-01-21
         url: http://url.com
         checksum: '1234'
 '''
@@ -56,7 +56,7 @@ FAKE_IMAGE_DICT : Dict[str, Any] = {
     'tags': [],
     'versions': [
         {
-            'build_date': '2021-01-21',
+            'build_date': date.fromisoformat("2021-01-21"),
             'version': '1',
             'url': 'http://url.com',
             'checksum': '1234'


### PR DESCRIPTION
This change will unify the build_date of all
images to a datetime object instead of a "stringify" datetime like object.

previously implemented logic to work with both formats, has also been dropped.

fixes #638