### PR TITLE
Disable Fedora 37 image by default

### DIFF
--- a/etc/images/fedora.yml
+++ b/etc/images/fedora.yml
@@ -2,7 +2,7 @@
 images:
 
   - name: Fedora 37
-    enable: true
+    enable: false
     shortname: fedora-37
     format: qcow2
     login: fedora


### PR DESCRIPTION
Fedora 37 is now out of date.