### PR TITLE
Provide compatibility with Python 3 versions older than 3.10

### DIFF
--- a/openstack_image_manager/manage.py
+++ b/openstack_image_manager/manage.py
@@ -8,6 +8,7 @@ import os
 import re
 import sys
 import typer
+import typing
 from typing import Dict, Set
 import yamale
 import urllib.parse
@@ -371,7 +372,7 @@ class ImageManager:
 
     def import_image(
         self, image: dict, name: str, url: str, versions: dict, version: str
-    ) -> Image | None:
+    ) -> typing.Union[Image, None]:
         """
         Create a new image in Glance and upload it using the web-download method
 
@@ -461,7 +462,7 @@ class ImageManager:
                     )
         return result
 
-    def wait_for_image(self, image: Image) -> Image | None:
+    def wait_for_image(self, image: Image) -> typing.Union[Image, None]:
         """
         Wait for an imported image to reach "active" state
 


### PR DESCRIPTION
The `X | Y` notation[^1] for typing in Python was introduced in Python 3.10 and makes `openstack-image-manager` fail on older Python versions such as 3.9:

```
$ openstack-image-manager --help
Traceback (most recent call last):
  ...
    ) -> Image | None:
TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'
```

This PR uses the backwards-compatible `typing.Union` instead which achieves the same and makes `openstack-image-manager` usable on older Python 3 releases as well.

[^1]: https://peps.python.org/pep-0604/