### PR TITLE
Add mirror_url to all existing image definitions

### DIFF
--- a/etc/images/almalinux.yml
+++ b/etc/images/almalinux.yml
@@ -28,6 +28,8 @@ images:
     versions:
       - version: '20231128'
         url: 
+          https://repo.almalinux.org/almalinux/8/cloud/x86_64/images/AlmaLinux-8-GenericCloud-latest.x86_64.qcow2
+        mirror_url: 
           https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/openstack-images/almalinux-8/20231128-almalinux-8.qcow2
         checksum: sha256:a1686bc537bce699b512e3233666f5b8f69ed797ff1ce0af52c17fdc52942621
         build_date: 2023-11-28
@@ -59,6 +61,8 @@ images:
     versions:
       - version: '20231113'
         url: 
+          https://repo.almalinux.org/almalinux/9/cloud/x86_64/images/AlmaLinux-9-GenericCloud-latest.x86_64.qcow2
+        mirror_url: 
           https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/openstack-images/almalinux-9/20231113-almalinux-9.qcow2
         checksum: sha256:6bbd060c971fd827a544c7e5e991a7d9e44460a449d2d058a0bb1290dec5a114
         build_date: 2023-11-13

--- a/etc/images/centos.yml
+++ b/etc/images/centos.yml
@@ -28,6 +28,8 @@ images:
     versions:
       - version: '20221112'
         url: 
+          https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud-HEREBE\d+\.qcow2$DRAGONS
+        mirror_url: 
           https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/openstack-images/centos-7/20221112-centos-7.qcow2
         checksum: sha256:284aab2b23d91318f169ff464bce4d53404a15a0618ceb34562838c59af4adea
         build_date: 2022-11-12
@@ -59,6 +61,8 @@ images:
     versions:
       - version: '20240326'
         url: 
+          https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-HEREBE\d+\.\dDRAGONS.x86_64.qcow2
+        mirror_url: 
           https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/openstack-images/centos-stream-8/20240326-centos-stream-8.qcow2
         checksum: sha256:35f5b4323026887470954cb458fa1628fac9db451663b37495067c5bbe7b345d
         build_date: 2024-03-26
@@ -90,6 +94,8 @@ images:
     versions:
       - version: '20240326'
         url: 
+          https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-HEREBE\d+\.\dDRAGONS.x86_64.qcow2
+        mirror_url: 
           https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/openstack-images/centos-stream-9/20240326-centos-stream-9.qcow2
         checksum: sha256:26a4d6d9750266d3a68cee2813aee0cc58751bf87303418b4fcdeeaa3f6dad96
         build_date: 2024-03-26

--- a/etc/images/debian.yml
+++ b/etc/images/debian.yml
@@ -28,6 +28,8 @@ images:
     versions:
       - version: '20240204'
         url: 
+          https://cdimage.debian.org/cdimage/cloud/buster/latest/debian-10-genericcloud-amd64.qcow2
+        mirror_url: 
           https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/openstack-images/debian-10/20240204-debian-10.qcow2
         checksum: 
           sha512:dc7c2d38824f8ad5db09237a1fa902b525f119e2f1504d0bf656879bf949a2366ba1ad9aa4ba9c6727fb98dd2379f317abe458c2d2c41830f9260e55a7fcef4a
@@ -59,6 +61,8 @@ images:
     versions:
       - version: '20240211'
         url: 
+          https://cdimage.debian.org/cdimage/cloud/bullseye/latest/debian-11-genericcloud-amd64.qcow2
+        mirror_url: 
           https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/openstack-images/debian-11/20240211-debian-11.qcow2
         checksum: 
           sha512:57ea3ba6855784f627730a16b8cb2b4e85a434f0626903dc9b036a10c0edf35242b86a1938bf84890ebbdba2b27e6d9ceff0a47da106e365f6d81077e4089a1c
@@ -92,5 +96,7 @@ images:
         checksum: 
           sha512:7d64f650164475b690690fe003f338e893374c412183d27834c80006a070581719e7e0311f8122a722390942b026c92b5ca3021e9c95b5807fe3bdf971d5edc7
         url: 
+          https://cdimage.debian.org/cdimage/cloud/bookworm/daily/latest/debian-12-genericcloud-amd64-daily.qcow2
+        mirror_url: 
           https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/openstack-images/debian-12/20240327-debian-12.qcow2
         version: '20240327'

--- a/etc/images/rockylinux.yml
+++ b/etc/images/rockylinux.yml
@@ -29,6 +29,8 @@ images:
     versions:
       - version: '20231119'
         url: 
+          https://download.rockylinux.org/pub/rocky/8/images/x86_64/Rocky-8-GenericCloud.latest.x86_64.qcow2
+        mirror_url: 
           https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/openstack-images/rocky-8/20231119-rocky-8.qcow2
         checksum: sha256:d17f15a7649dd064795306c114b90fc5062e7d5fefa9e9f0bd6b7ce1aeac3ae5
         build_date: 2023-11-19
@@ -61,6 +63,8 @@ images:
     versions:
       - version: '20231113'
         url: 
+          https://download.rockylinux.org/pub/rocky/9/images/x86_64/Rocky-9-GenericCloud.latest.x86_64.qcow2
+        mirror_url: 
           https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/openstack-images/rocky-9/20231113-rocky-9.qcow2
         checksum: sha256:7713278c37f29b0341b0a841ca3ec5c3724df86b4d97e7ee4a2a85def9b2e651
         build_date: 2023-11-13

--- a/etc/images/ubuntu.yml
+++ b/etc/images/ubuntu.yml
@@ -28,6 +28,8 @@ images:
     versions:
       - version: '20191107'
         url: 
+          https://cloud-images.ubuntu.com/trusty/current/trusty-server-cloudimg-amd64-disk1.img
+        mirror_url: 
           https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/openstack-images/ubuntu-14.04/20191107-ubuntu-14.04.qcow2
         checksum: sha256:3c4ad0defbe729dd3c16d2851d775575d1c5351c85734418d3b89bfdfd28ebd1
         build_date: 2019-11-07
@@ -59,6 +61,8 @@ images:
     versions:
       - version: '20211001'
         url: 
+          https://cloud-images.ubuntu.com/xenial/current/xenial-server-cloudimg-amd64-disk1.img
+        mirror_url: 
           https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/openstack-images/ubuntu-16.04/20211001-ubuntu-16.04.qcow2
         checksum: sha256:fff2494a70bcaffb59f26f71ec49e137dd87d319341c35832dbe0ea65ff15140
         build_date: 2021-10-01
@@ -90,6 +94,8 @@ images:
     versions:
       - version: '20210929'
         url: 
+          https://cloud-images.ubuntu.com/minimal/releases/xenial/release/ubuntu-16.04-minimal-cloudimg-amd64-disk1.img
+        mirror_url: 
           https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/openstack-images/ubuntu-16.04-minimal/20210929-ubuntu-16.04-minimal.qcow2
         checksum: sha256:7658ec30373e7ad1a1858744f395a89713d333721d7d1986ee8b71680b81a0a9
         build_date: 2021-09-20
@@ -119,7 +125,8 @@ images:
     latest_url: https://cloud-images.ubuntu.com/bionic/current/bionic-server-cloudimg-amd64.img
     versions:
       - version: '20230607'
-        url: 
+        url: https://cloud-images.ubuntu.com/bionic/current/bionic-server-cloudimg-amd64.img
+        mirror_url: 
           https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/openstack-images/ubuntu-18.04/20230607-ubuntu-18.04.qcow2
         checksum: sha256:8dd2e6b5e5aad20c3f836123b300cba9861249408cbb07c359145a65d6bab6b6
         build_date: 2023-06-07
@@ -151,6 +158,8 @@ images:
     versions:
       - version: '20230602'
         url: 
+          https://cloud-images.ubuntu.com/minimal/releases/bionic/release/ubuntu-18.04-minimal-cloudimg-amd64.img
+        mirror_url: 
           https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/openstack-images/ubuntu-18.04-minimal/20230602-ubuntu-18.04-minimal.qcow2
         checksum: sha256:2d9755669c499e88d51da0638cd20e0983a248828e2153906c013bea0ee2f45a
         build_date: 2023-06-02
@@ -180,7 +189,8 @@ images:
     latest_url: https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img
     versions:
       - version: '20240306'
-        url: 
+        url: https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img
+        mirror_url: 
           https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/openstack-images/ubuntu-20.04/20240306-ubuntu-20.04.qcow2
         checksum: sha256:edf43eb9f4e5ededbb3606c719c98b0e14c956278da42567e907a17d8bccb571
         build_date: 2024-03-06
@@ -212,6 +222,8 @@ images:
     versions:
       - version: '20240322'
         url: 
+          https://cloud-images.ubuntu.com/minimal/releases/focal/release/ubuntu-20.04-minimal-cloudimg-amd64.img
+        mirror_url: 
           https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/openstack-images/ubuntu-20.04-minimal/20240322-ubuntu-20.04-minimal.qcow2
         checksum: sha256:25b920bd472450e31c836c1759f8fb72b4b4694654e478987744a5c77034d311
         build_date: 2024-03-22
@@ -241,7 +253,8 @@ images:
     latest_url: https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img
     versions:
       - version: '20240319'
-        url: 
+        url: https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img
+        mirror_url: 
           https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/openstack-images/ubuntu-22.04/20240319-ubuntu-22.04.qcow2
         checksum: sha256:304983616fcba6ee1452e9f38993d7d3b8a90e1eb65fb0054d672ce23294d812
         build_date: 2024-03-19
@@ -273,6 +286,8 @@ images:
     versions:
       - version: '20240319'
         url: 
+          https://cloud-images.ubuntu.com/minimal/releases/jammy/release/ubuntu-22.04-minimal-cloudimg-amd64.img
+        mirror_url: 
           https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/openstack-images/ubuntu-22.04-minimal/20240319-ubuntu-22.04-minimal.qcow2
         checksum: sha256:24c513a5c10cd57c68403c800dc47495ff0eceea81d7946b512f0260a9c55f6e
         build_date: 2024-03-19


### PR DESCRIPTION
This is a workaround for all existing images that will not be updated in the (near) future.

Related to osism/issues#913