### PR TITLE
Set the hypervisor_type for all images to qemu

### DIFF
--- a/etc/images/almalinux.yml
+++ b/etc/images/almalinux.yml
@@ -16,6 +16,7 @@ images:
       hw_rng_model: virtio
       hw_scsi_model: virtio-scsi
       hw_watchdog_action: reset
+      hypervisor_type: qemu
       os_distro: centos
       os_version: '8'
       replace_frequency: quarterly
@@ -49,6 +50,7 @@ images:
       hw_rng_model: virtio
       hw_scsi_model: virtio-scsi
       hw_watchdog_action: reset
+      hypervisor_type: qemu
       os_distro: centos
       os_version: '9'
       replace_frequency: quarterly

--- a/etc/images/centos.yml
+++ b/etc/images/centos.yml
@@ -16,6 +16,7 @@ images:
       hw_rng_model: virtio
       hw_scsi_model: virtio-scsi
       hw_watchdog_action: reset
+      hypervisor_type: qemu
       os_distro: centos
       os_version: '7'
       replace_frequency: critical_bug
@@ -49,6 +50,7 @@ images:
       hw_rng_model: virtio
       hw_scsi_model: virtio-scsi
       hw_watchdog_action: reset
+      hypervisor_type: qemu
       os_distro: centos
       os_version: '8'
       replace_frequency: quarterly
@@ -82,6 +84,7 @@ images:
       hw_rng_model: virtio
       hw_scsi_model: virtio-scsi
       hw_watchdog_action: reset
+      hypervisor_type: qemu
       os_distro: centos
       os_version: '9'
       replace_frequency: quarterly

--- a/etc/images/cirros.yml
+++ b/etc/images/cirros.yml
@@ -17,6 +17,7 @@ images:
       hw_rng_model: virtio
       hw_scsi_model: virtio-scsi
       hw_watchdog_action: reset
+      hypervisor_type: qemu
       os_distro: cirros
       replace_frequency: never
       uuid_validity: none

--- a/etc/images/clearlinux.yml
+++ b/etc/images/clearlinux.yml
@@ -17,6 +17,7 @@ images:
       hw_rng_model: virtio
       hw_scsi_model: virtio-scsi
       hw_watchdog_action: reset
+      hypervisor_type: qemu
       os_distro: clearlinux
       replace_frequency: never
       uuid_validity: none

--- a/etc/images/debian.yml
+++ b/etc/images/debian.yml
@@ -16,6 +16,7 @@ images:
       hw_rng_model: virtio
       hw_scsi_model: virtio-scsi
       hw_watchdog_action: reset
+      hypervisor_type: qemu
       os_distro: debian
       os_version: '10'
       replace_frequency: quarterly
@@ -50,6 +51,7 @@ images:
       hw_rng_model: virtio
       hw_scsi_model: virtio-scsi
       hw_watchdog_action: reset
+      hypervisor_type: qemu
       os_distro: debian
       os_version: '11'
       replace_frequency: quarterly
@@ -84,6 +86,7 @@ images:
       hw_rng_model: virtio
       hw_scsi_model: virtio-scsi
       hw_watchdog_action: reset
+      hypervisor_type: qemu
       os_distro: debian
       os_version: '12'
       replace_frequency: quarterly

--- a/etc/images/fedora.yml
+++ b/etc/images/fedora.yml
@@ -17,6 +17,7 @@ images:
       hw_scsi_model: virtio-scsi
       hw_rng_model: virtio
       hw_watchdog_action: reset
+      hypervisor_type: qemu
       os_distro: fedora
       os_version: '37'
       replace_frequency: quarterly

--- a/etc/images/flatcar.yml
+++ b/etc/images/flatcar.yml
@@ -17,6 +17,7 @@ images:
       hw_rng_model: virtio
       hw_scsi_model: virtio-scsi
       hw_watchdog_action: reset
+      hypervisor_type: qemu
       os_distro: fedora
       replace_frequency: never
       uuid_validity: none

--- a/etc/images/gardenlinux.yml
+++ b/etc/images/gardenlinux.yml
@@ -16,6 +16,7 @@ images:
       hw_rng_model: virtio
       hw_scsi_model: virtio-scsi
       hw_watchdog_action: reset
+      hypervisor_type: qemu
       os_distro: debian
       replace_frequency: never
       uuid_validity: none

--- a/etc/images/kubernetes.yml
+++ b/etc/images/kubernetes.yml
@@ -16,6 +16,7 @@ images:
       hw_rng_model: virtio
       hw_scsi_model: virtio-scsi
       hw_watchdog_action: reset
+      hypervisor_type: qemu
       os_distro: ubuntu
       replace_frequency: never
       uuid_validity: none

--- a/etc/images/opensuse.yml
+++ b/etc/images/opensuse.yml
@@ -16,6 +16,7 @@ images:
       hw_rng_model: virtio
       hw_scsi_model: virtio-scsi
       hw_watchdog_action: reset
+      hypervisor_type: qemu
       os_distro: opensuse
       os_version: '15.4'
       replace_frequency: quarterly

--- a/etc/images/opnsense.yml
+++ b/etc/images/opnsense.yml
@@ -18,6 +18,7 @@ images:
       hw_rng_model: virtio
       hw_scsi_model: virtio-scsi
       hw_watchdog_action: reset
+      hypervisor_type: qemu
       os_distro: freebsd
       replace_frequency: never
       uuid_validity: none

--- a/etc/images/osism.yml
+++ b/etc/images/osism.yml
@@ -16,6 +16,7 @@ images:
       hw_rng_model: virtio
       hw_scsi_model: virtio-scsi
       hw_watchdog_action: reset
+      hypervisor_type: qemu
       os_distro: ubuntu
       os_version: '22.04'
       replace_frequency: quarterly

--- a/etc/images/rockylinux.yml
+++ b/etc/images/rockylinux.yml
@@ -16,6 +16,7 @@ images:
       hw_rng_model: virtio
       hw_scsi_model: virtio-scsi
       hw_watchdog_action: reset
+      hypervisor_type: qemu
       os_distro: centos
       os_version: '8'
       replace_frequency: quarterly
@@ -50,6 +51,7 @@ images:
       hw_rng_model: virtio
       hw_scsi_model: virtio-scsi
       hw_watchdog_action: reset
+      hypervisor_type: qemu
       os_distro: centos
       os_version: '9'
       replace_frequency: quarterly

--- a/etc/images/talos.yml
+++ b/etc/images/talos.yml
@@ -17,6 +17,7 @@ images:
       hw_rng_model: virtio
       hw_scsi_model: virtio-scsi
       hw_watchdog_action: reset
+      hypervisor_type: qemu
       os_distro: talos
       replace_frequency: never
       uuid_validity: none

--- a/etc/images/ubuntu.yml
+++ b/etc/images/ubuntu.yml
@@ -16,6 +16,7 @@ images:
       hw_rng_model: virtio
       hw_scsi_model: virtio-scsi
       hw_watchdog_action: reset
+      hypervisor_type: qemu
       os_distro: ubuntu
       os_version: '14.04'
       replace_frequency: never
@@ -49,6 +50,7 @@ images:
       hw_rng_model: virtio
       hw_scsi_model: virtio-scsi
       hw_watchdog_action: reset
+      hypervisor_type: qemu
       os_distro: ubuntu
       os_version: '16.04'
       replace_frequency: never
@@ -82,6 +84,7 @@ images:
       hw_rng_model: virtio
       hw_scsi_model: virtio-scsi
       hw_watchdog_action: reset
+      hypervisor_type: qemu
       os_distro: ubuntu
       os_version: '16.04'
       replace_frequency: never
@@ -115,6 +118,7 @@ images:
       hw_rng_model: virtio
       hw_scsi_model: virtio-scsi
       hw_watchdog_action: reset
+      hypervisor_type: qemu
       os_distro: ubuntu
       os_version: '18.04'
       replace_frequency: quarterly
@@ -146,6 +150,7 @@ images:
       hw_rng_model: virtio
       hw_scsi_model: virtio-scsi
       hw_watchdog_action: reset
+      hypervisor_type: qemu
       os_distro: ubuntu
       os_version: '18.04'
       replace_frequency: quarterly
@@ -179,6 +184,7 @@ images:
       hw_rng_model: virtio
       hw_scsi_model: virtio-scsi
       hw_watchdog_action: reset
+      hypervisor_type: qemu
       os_distro: ubuntu
       os_version: '20.04'
       replace_frequency: quarterly
@@ -210,6 +216,7 @@ images:
       hw_rng_model: virtio
       hw_scsi_model: virtio-scsi
       hw_watchdog_action: reset
+      hypervisor_type: qemu
       os_distro: ubuntu
       os_version: '20.04'
       replace_frequency: quarterly
@@ -243,6 +250,7 @@ images:
       hw_rng_model: virtio
       hw_scsi_model: virtio-scsi
       hw_watchdog_action: reset
+      hypervisor_type: qemu
       os_distro: ubuntu
       os_version: '22.04'
       replace_frequency: quarterly
@@ -274,6 +282,7 @@ images:
       hw_rng_model: virtio
       hw_scsi_model: virtio-scsi
       hw_watchdog_action: reset
+      hypervisor_type: qemu
       os_distro: ubuntu
       os_version: '22.04'
       replace_frequency: quarterly
@@ -307,6 +316,7 @@ images:
       hw_rng_model: virtio
       hw_scsi_model: virtio-scsi
       hw_watchdog_action: reset
+      hypervisor_type: qemu
       os_distro: ubuntu
       os_version: '24.04'
       replace_frequency: quarterly

--- a/etc/schema.yaml
+++ b/etc/schema.yaml
@@ -24,6 +24,7 @@ image:
 ---
 meta:
   architecture: enum('x86_64', 'aarch64', 'risc-v')
+  hypervisor_type: enum('hyperv', 'ironic', 'lxc', 'qemu', 'uml', 'vmware', 'xen')
   hotfix_hours: int(min=0, required=False)
   hw_disk_bus: enum('virtio', 'scsi', None)
   hw_rng_model: enum('virtio', None, required=False)

--- a/openstack_image_manager/main.py
+++ b/openstack_image_manager/main.py
@@ -60,9 +60,6 @@ class ImageManager:
         filter: str = typer.Option(
             None, help="Filter images with a regex on their name"
         ),
-        hypervisor: str = typer.Option(
-            None, help="Set hypervisor type meta information"
-        ),
         deactivate: bool = typer.Option(
             False, "--deactivate", help="Deactivate images that should be deleted"
         ),
@@ -753,10 +750,6 @@ class ImageManager:
 
             logger.info(f"Setting image_original_user = {image['login']}")
             image["meta"]["image_original_user"] = image["login"]
-
-            if self.CONF.hypervisor:
-                logger.info(f"Setting hypervisor type = {self.CONF.hypervisor}")
-                image["meta"]["hypervisor_type"] = self.CONF.hypervisor
 
             if version == "latest" and upstream_checksum:
                 image["meta"]["upstream_checksum"] = upstream_checksum


### PR DESCRIPTION
This also removes the hypervisor CLI parameter. It makes no sense to change the hypervisor for all images as the hypervisor is defined for each image.