### PR TITLE
Fix usage of outdated module name

### DIFF
--- a/openstack_image_manager/main.py
+++ b/openstack_image_manager/main.py
@@ -119,7 +119,7 @@ class ImageManager:
         logger.remove()
         logger.add(sys.stderr, format=log_fmt, level=level, colorize=True)
 
-        if __name__ == "__main__" or __name__ == "openstack_image_manager.manage":
+        if __name__ == "__main__" or __name__ == "openstack_image_manager.main":
             self.main()
 
     def read_image_files(self, return_all_images=False) -> list:


### PR DESCRIPTION
The module `openstack_image_manager.manage` was renamed to `openstack_image_manager.main` in a previous commit. A condition checking the module name was fixed to reflect this change.