### PR TITLE
Add separator to schema.yaml

### DIFF
--- a/.github/workflows/validate-configuration.yml
+++ b/.github/workflows/validate-configuration.yml
@@ -24,6 +24,6 @@ jobs:
         with:
           python-version: '3.x'
       - run: pip3 install tox
-      - run: tox -- --check
+      - run: tox -- --check-only
         env:
           OS_CLIENT_CONFIG_FILE: .github/clouds.yml

--- a/etc/schema.yaml
+++ b/etc/schema.yaml
@@ -17,6 +17,7 @@ image:
   password: str(required=False)
   shortname: str(required=False)
   status: enum('active', 'deactivated')
+  separator: str(required=False)
   tags: list(str())
   versions: list(include('versions'))
   visibility: enum('public', 'private', 'community', 'shared')

--- a/openstack_image_manager/main.py
+++ b/openstack_image_manager/main.py
@@ -94,7 +94,12 @@ class ImageManager:
         check: bool = typer.Option(
             True,
             "--check/--no-check",
-            help="Check the local image definitions against the SCS Image Metadata Standard",
+            help="Check the local image definitions against the SCS Image Metadata Standard (and process the images)",
+        ),
+        check_only: bool = typer.Option(
+            False,
+            "--check-only",
+            help="Quit after checking the image definitions against the SCS Image Metadata Standard",
         ),
     ):
         self.CONF = Munch.fromDict(locals())
@@ -209,8 +214,11 @@ class ImageManager:
         )
 
         # check local image definitions with yamale
-        if self.CONF.check:
+        if self.CONF.check or self.CONF.check_only:
             self.validate_yaml_schema()
+
+        if self.CONF.check_only:
+            return
 
         # share image (previously share.py)
         if self.CONF.share_image:

--- a/test/unit/test_manage.py
+++ b/test/unit/test_manage.py
@@ -145,6 +145,7 @@ class TestManage(TestCase):
             share_type="project",
             filter="",
             check=False,
+            check_only=False,
             hypervisor=None,
         )
 
@@ -663,7 +664,6 @@ class TestManage(TestCase):
 
         # test with check = True
         self.sot.CONF.check = True
-
         self.sot.CONF.dry_run = False
 
         self.sot.main()
@@ -675,16 +675,57 @@ class TestManage(TestCase):
         mock_share_image.assert_not_called()
         mock_unshare_image.assert_not_called()
 
-    @mock.patch("openstack_image_manager.main.ImageManager.read_image_files")
-    @mock.patch("openstack_image_manager.main.openstack.connect")
-    def test_validate_images(
-        self,
-        mock_connect,
-        mock_read_image_files,
-    ):
-        """Validate the image definitions in this repo against the schema"""
+        # reset
+        mock_connect.reset_mock()
+        mock_read_image_files.reset_mock()
+        mock_get_images.reset_mock()
+        mock_process_images.reset_mock()
+        mock_manage_outdated.reset_mock()
+        mock_validate_yaml.reset_mock()
+        mock_share_image.reset_mock()
+        mock_unshare_image.reset_mock()
+
+        # test with check_only = True
+        self.sot.CONF.check = False
+        self.sot.CONF.check_only = True
+        self.sot.CONF.dry_run = False
+
+        self.sot.main()
+        mock_connect.assert_not_called()
+        mock_read_image_files.assert_not_called()
+        mock_process_images.assert_not_called()
+        mock_manage_outdated.assert_not_called()
+        mock_validate_yaml.assert_called_once()
+        mock_share_image.assert_not_called()
+        mock_unshare_image.assert_not_called()
+
+        # reset
+        mock_connect.reset_mock()
+        mock_read_image_files.reset_mock()
+        mock_get_images.reset_mock()
+        mock_process_images.reset_mock()
+        mock_manage_outdated.reset_mock()
+        mock_validate_yaml.reset_mock()
+        mock_share_image.reset_mock()
+        mock_unshare_image.reset_mock()
+
+        # test with check_only = True and check = True
         self.sot.CONF.check = True
-        self.sot.CONF.dry_run = True
+        self.sot.CONF.check_only = True
+        self.sot.CONF.dry_run = False
+
+        self.sot.main()
+        mock_connect.assert_not_called()
+        mock_read_image_files.assert_not_called()
+        mock_process_images.assert_not_called()
+        mock_manage_outdated.assert_not_called()
+        mock_validate_yaml.assert_called_once()
+        mock_share_image.assert_not_called()
+        mock_unshare_image.assert_not_called()
+
+    def test_validate_images(self):
+        """Validate the image definitions in this repo against the schema"""
+        self.sot.CONF.check_only = True
 
         # When image validation fails, we sys.exit and fail the test
         self.sot.main()


### PR DESCRIPTION
Every call of openstack_image_manager will now validate the image yamls against the schema before managing the images. (Previously check defaulted to ``False`` and exited without managing the images)

Furthermore add the option ``--check-only`` used if only the validation is desired but not managing the images (for example in CI pipelines)