### PR TITLE
Change min_ram for cirros to 64 MiB

### DIFF
--- a/etc/images/cirros.yml
+++ b/etc/images/cirros.yml
@@ -7,7 +7,7 @@ images:
     login: cirros
     password: gocubsgo
     min_disk: 1
-    min_ram: 32
+    min_ram: 64
     status: active
     visibility: public
     multi: false


### PR DESCRIPTION
We're getting a warning in the SCS compliance check
```
WARNING: property min_ram < 64 MiB for image(s): Cirros 0.6.2, Cirros 0.6.1, Cirros 0.6.0
```

See: https://github.com/SovereignCloudStack/standards/blob/24b80337280ce6ab8a0478032a58756dc742810b/Tests/iaas/scs_0102_image_metadata/image_metadata.py#L139

I think it makes sense to change this to 64 MiB?