### PR TITLE
Add --stuck-retry option for retrying stuck image imports

### DIFF
--- a/test/unit/test_manage.py
+++ b/test/unit/test_manage.py
@@ -147,6 +147,7 @@ class TestManage(TestCase):
             check=False,
             check_only=False,
             hypervisor=None,
+            stuck_retry=0,
         )
 
         # we can also mimick an openstack connection object with a Munch


### PR DESCRIPTION
When an image gets stuck in queued state during web-download import, the image manager can now automatically delete the stuck image and retry the import. The number of retry attempts is configurable via the new --stuck-retry CLI option (default: 0, no retry).

AI-assisted: Claude Code