### PR TITLE
ci: use stable branch name for update-images workflow

### DIFF
--- a/.github/workflows/update-images.yml
+++ b/.github/workflows/update-images.yml
@@ -42,7 +42,7 @@ jobs:
 
             Signed-off-by: OSISM Bot <bot@osism.tech>
           committer: OSISM Bot <bot@osism.tech>
-          branch: updates-images-${{ github.run_number }}-${{ matrix.image }}
+          branch: updates-images-${{ matrix.image }}
           delete-branch: true
           title: "chore: update ${{ matrix.image }} images"
           body: |


### PR DESCRIPTION
Reuse one PR per image across weekly runs instead of creating a new branch each time, so reviews and history carry over.