### PR TITLE
Fix black 26.3.1 formatting

### DIFF
--- a/contrib/mirror.py
+++ b/contrib/mirror.py
@@ -18,7 +18,6 @@ from os.path import isfile, join
 from pathlib import Path
 from urllib.parse import urlparse
 
-
 app = typer.Typer(add_completion=False)
 
 

--- a/contrib/table.py
+++ b/contrib/table.py
@@ -8,7 +8,6 @@ from munch import Munch
 from os import listdir
 from os.path import isfile, join
 
-
 app = typer.Typer(add_completion=False)
 
 


### PR DESCRIPTION
## Summary
- Reformat code to comply with black 26.3.1 stable style (updated in osism/zuul-jobs#180)

## Test plan
- [ ] python-black Zuul job passes