### PR TITLE
ADD etc/images/ubuntu_core.yml

### DIFF
--- a/etc/images/ubuntu_core.yml
+++ b/etc/images/ubuntu_core.yml
@@ -1,0 +1,38 @@
+---
+images:
+  - name: Ubuntu Core 26
+    enable: true
+    shortname: ubuntu-core-26
+    format: qcow2
+    login: ubuntu
+    min_disk: 8
+    min_ram: 512
+    status: active
+    visibility: public
+    multi: true
+    meta:
+      architecture: x86_64
+      hw_firmware_type: uefi
+      hw_disk_bus: scsi
+      hw_rng_model: virtio
+      hw_scsi_model: virtio-scsi
+      hw_watchdog_action: reset
+      hypervisor_type: qemu
+      os_distro: ubuntu
+      os_version: '26.04'
+      os_purpose: minimal
+      replace_frequency: quarterly
+      uuid_validity: last-3
+      provided_until: none
+    tags: []
+    latest_checksum_url:
+      https://cdimage.ubuntu.com/ubuntu-core/26/stable/current/SHA256SUMS
+    latest_url:
+      https://cdimage.ubuntu.com/ubuntu-core/26/stable/current/ubuntu-core-26-amd64.qcow2
+    versions:
+      - version: '20260606.1'
+        url:
+          https://cdimage.ubuntu.com/ubuntu-core/26/stable/20260606.1/ubuntu-core-26-amd64.qcow2
+        checksum:
+          sha256:f8aef3d6ec1786478c9640c3c50346160fbd346be09c2e42f10e7bd85bb6ab7f
+        build_date: 2026-06-06


### PR DESCRIPTION
Requires booting via UEFI, hence it sets `meta.hw_firmware_type` to "uefi". This currently breaks the processing...

See #1097