### PR TITLE
etc/schema.yaml: add hw_firmware_type

### DIFF
--- a/etc/schema.yaml
+++ b/etc/schema.yaml
@@ -27,6 +27,7 @@ meta:
   architecture: enum('x86_64', 'aarch64', 'risc-v')
   hotfix_hours: int(min=0, required=False)
   hw_disk_bus: enum('virtio', 'scsi', None)
+  hw_firmware_type: enum('uefi', None, required=False)
   hw_rng_model: enum('virtio', None, required=False)
   hw_scsi_model: enum('virtio-scsi', required=False)
   hw_vif_multiqueue_enabled: bool(required=False)


### PR DESCRIPTION
Fixes #1097

Not sure if there is anything else that needs to be added (I have not looked into tests yet).

I found no other value for this, it seems to be either set to `uefi` or left out.