### PR TITLE
ci: use stable branch name for gardenlinux update workflow

### DIFF
--- a/.github/workflows/update-image-gardenlinux.yml
+++ b/.github/workflows/update-image-gardenlinux.yml
@@ -34,9 +34,9 @@ jobs:
 
             Signed-off-by: OSISM Bot <bot@osism.tech>
           committer: OSISM Bot <bot@osism.tech>
-          branch: updates-image-gardenlinux-${{ github.run_number }}
+          branch: updates-image-gardenlinux
           delete-branch: true
-          title: "chore: update gardenlinux mage"
+          title: "chore: update gardenlinux image"
           body: |
             chore: update gardenlinux image
 


### PR DESCRIPTION
## Problem

The `update-image-gardenlinux.yml` workflow used a branch name derived from the run number (`updates-image-gardenlinux-${{ github.run_number }}`). Because peter-evans/create-pull-request opens one PR per unique branch, every scheduled run created a **new** branch and a **new** PR, leading to dozens of accumulated open PRs.

The equivalent `update-images.yml` workflow was already fixed to use a stable branch name in #1208; this brings the gardenlinux workflow in line.

## Change

- Use a fixed branch name `updates-image-gardenlinux` instead of one per run.
- Fix the PR title typo `mage` → `image`.

## Result

There is now exactly **one branch and one PR** for the gardenlinux image:

- No merge, new change → the existing PR is updated (force-push), no new PR is opened.
- No merge, no change → the PR stays as is.
- After merge / no more diffs → `delete-branch: true` cleans up branch and PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)