### PR TITLE
Add hw_firmware_type and hw_machine_type to meta schema

### DIFF
--- a/etc/schema.yaml
+++ b/etc/schema.yaml
@@ -27,6 +27,8 @@ meta:
   architecture: enum('x86_64', 'aarch64', 'risc-v')
   hotfix_hours: int(min=0, required=False)
   hw_disk_bus: enum('virtio', 'scsi', None)
+  hw_firmware_type: enum('uefi', None, required=False)
+  hw_machine_type: enum('pc', 'q35', 'virt', None, required=False)
   hw_rng_model: enum('virtio', None, required=False)
   hw_scsi_model: enum('virtio-scsi', required=False)
   hw_vif_multiqueue_enabled: bool(required=False)


### PR DESCRIPTION
Adds two missing keys to the `meta` schema in `etc/schema.yaml`. Using either of them in an image definition previously failed validation with `Unexpected element`.

- `hw_firmware_type: enum('uefi', None)` — required e.g. for images that must boot via UEFI. Incorporates the change from #1233.
- `hw_machine_type: enum('pc', 'q35', 'virt', None)` — needed alongside `hw_firmware_type` (e.g. `q35`).

Both keys are optional (`required=False`).

Validated with yamale: the new values are accepted, invalid values (e.g. `hw_firmware_type: bios`, `hw_machine_type: bogus`) are rejected, and all existing `etc/images/*.yml` definitions still validate.

Fixes #1097
Closes #1236

This supersedes #1233 (combined here with the `hw_machine_type` addition); the original `hw_firmware_type` change is credited to @johanneskastl via `Co-authored-by`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)