### PR TITLE
Drop setuptools as a direct runtime dependency

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -16,4 +16,3 @@ requests = "==2.34.2"
 tabulate = "==0.10.0"
 typer = {extras = ["all"], version = "==0.26.7"}
 yamale = "==6.1.0"
-setuptools = "==82.0.1"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "bd0bf81b10e9cf1340d22509cacd6c433f68b88912598f474d68318c7fe73676"
+            "sha256": "bbb2fa2fe0b0b7c1b15dce157c33c3202bce95593bb6f77c5664ec6c034ccf1e"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -828,7 +828,6 @@
                 "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9",
                 "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb"
             ],
-            "index": "pypi",
             "markers": "python_version >= '3.9'",
             "version": "==82.0.1"
         },

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ paramiko==5.0.0
 patool==4.0.5
 requests==2.34.2
 ruamel.yaml==0.19.1
-setuptools==82.0.1
 tabulate==0.10.0
 typer[all]==0.26.7
 yamale==6.1.0


### PR DESCRIPTION
Fixes #1234

## Background

`setuptools` was listed as a **direct runtime dependency** in `requirements.txt` and `Pipfile` (added in #863). However, the project itself does not import `setuptools` or `pkg_resources` at runtime — version detection uses `importlib.metadata` (stdlib) in `openstack_image_manager/__init__.py`.

The `setuptools>=61.0.0` entry in `pyproject.toml` is a **build** dependency (`[build-system].requires`) and is unrelated/unchanged.

## What changed

- Removed the redundant `setuptools==82.0.1` pin from `requirements.txt` and `Pipfile`.
- Regenerated `Pipfile.lock`.

`setuptools` is still pulled in **transitively** as a runtime dependency of `pbr` (`openstacksdk` → `keystoneauth1`/`os-service-types` → `pbr`), so it remains installed. The relock keeps `setuptools` at `==82.0.1` with **no other package version changes** — only the direct-dependency marker and the meta hash differ.

The original rationale (providing `pkg_resources` under Python 3.12+, where setuptools is no longer pre-installed in venvs) no longer applies regardless: setuptools removed `pkg_resources` in v81, so the pinned `82.0.1` does not ship `pkg_resources` anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)