### PR TITLE
Align os_distro schema values with Glance docs

### DIFF
--- a/etc/images/rockylinux.yml
+++ b/etc/images/rockylinux.yml
@@ -17,7 +17,7 @@ images:
       hw_scsi_model: virtio-scsi
       hw_watchdog_action: reset
       hypervisor_type: qemu
-      os_distro: centos
+      os_distro: rocky
       os_version: '8'
       os_purpose: generic
       replace_frequency: quarterly
@@ -54,7 +54,7 @@ images:
       hw_scsi_model: virtio-scsi
       hw_watchdog_action: reset
       hypervisor_type: qemu
-      os_distro: centos
+      os_distro: rocky
       os_version: '9'
       os_purpose: generic
       replace_frequency: quarterly

--- a/etc/schema.yaml
+++ b/etc/schema.yaml
@@ -35,7 +35,10 @@ meta:
   hw_watchdog_action: enum('disabled', 'reset', 'poweroff', 'pause', 'none', required=False)
   hypervisor_type: enum('hyperv', 'ironic', 'lxc', 'qemu', 'uml', 'vmware', 'xen')
   image_description: str(required=False)
-  os_distro: enum('arch', 'centos', 'cirros', 'clearlinux', 'debian', 'fedora', 'freebsd', 'opensuse', 'rhel', 'talos', 'ubuntu', 'windows')
+  # Permissible values as documented for the os_distro property
+  # (https://docs.openstack.org/glance/latest/admin/useful-image-properties),
+  # extended with 'cirros' and 'talos' for which no official value exists.
+  os_distro: enum('arch', 'centos', 'cirros', 'debian', 'fedora', 'freebsd', 'gentoo', 'mandrake', 'mandriva', 'mes', 'msdos', 'netbsd', 'netware', 'openbsd', 'opensolaris', 'opensuse', 'rhel', 'rocky', 'sled', 'talos', 'ubuntu', 'windows')
   os_version: str(required=False)
   os_purpose: enum('generic', 'minimal', 'k8snode', 'gpu', 'network', 'custom')
   patchlevel: str(required=False)


### PR DESCRIPTION
## What

Aligns the `os_distro` enum in `etc/schema.yaml` with the values documented for the property in the [OpenStack Glance docs](https://docs.openstack.org/glance/latest/admin/useful-image-properties).

### Schema (`etc/schema.yaml`)
- **Added** the documented values that were missing: `rocky` (the subject of #1105), plus `gentoo`, `mandrake`, `mandriva`, `mes`, `msdos`, `netbsd`, `netware`, `openbsd`, `opensolaris`, `sled`.
- **Removed** `clearlinux` — not documented and no longer used by any image definition.
- **Kept** `cirros` and `talos` — both are used by existing image definitions (`cirros.yml`, `talos.yml`) and have no official `os_distro` value. A comment documents this exception.

### Rocky Linux (`etc/images/rockylinux.yml`)
- Now that `rocky` is permitted, switched the Rocky 8 and Rocky 9 images from the `centos` workaround to `os_distro: rocky`. Note: this changes the resulting image tag from `os:centos` to `os:rocky`.

## Verification

All 12 image definitions under `etc/images/` validate cleanly against the updated schema with `yamale`.

Closes #1105

🤖 Generated with [Claude Code](https://claude.com/claude-code)