### PR TITLE
Import file:// URLs via glance-direct

### DIFF
--- a/openstack_image_manager/main.py
+++ b/openstack_image_manager/main.py
@@ -523,20 +523,22 @@ class ImageManager:
         parsed_url = urllib.parse.urlparse(url)
         if parsed_url.scheme == "file":
             new_image = self.conn.image.create_image(**properties)
-            local_file = open(parsed_url.path, "rb")
-            with local_file:
-                try:
-                    logger.info(
-                        f"Uploading local file '{parsed_url.path}' as image {name}"
-                    )
-                    new_image.data = local_file
-                    new_image.upload(self.conn.image)
-                except Exception as e:
-                    self.conn.image.delete_image(new_image)
-                    logger.error(f"Failed to upload local file for image {name}\n{e}")
-                    self.exit_with_error = True
-                    return None
-            return self.wait_for_image(new_image)
+            try:
+                logger.info(f"Importing local file '{parsed_url.path}' as image {name}")
+                result = self._glance_direct_import(
+                    new_image,
+                    parsed_url.path,
+                    time.monotonic() + self.CONF.import_timeout,
+                )
+            except Exception as e:
+                self.conn.image.delete_image(new_image)
+                logger.error(f"Failed to import local file for image {name}\n{e}")
+                self.exit_with_error = True
+                return None
+            if result is None:
+                self.conn.image.delete_image(new_image)
+                self.exit_with_error = True
+            return result
 
         deadline = time.monotonic() + self.CONF.import_timeout
         fallback_reserve = 900.0  # seconds kept for aria2 + staging + glance-direct

--- a/test/unit/test_manage.py
+++ b/test/unit/test_manage.py
@@ -225,6 +225,9 @@ class TestManage(TestCase):
         self.assertEqual(result, expected_result)
 
     @mock.patch(
+        "openstack_image_manager.main.openstack.image.v2._proxy.Proxy.stage_image"
+    )
+    @mock.patch(
         "openstack_image_manager.main.openstack.image.v2._proxy.Proxy.get_image"
     )
     @mock.patch(
@@ -233,8 +236,7 @@ class TestManage(TestCase):
     @mock.patch(
         "openstack_image_manager.main.openstack.image.v2._proxy.Proxy.create_image"
     )
-    @mock.patch("builtins.open")
-    def test_import_image(self, mock_open, mock_create, mock_import, mock_get_image):
+    def test_import_image(self, mock_create, mock_import, mock_get_image, mock_stage):
         """test main.ImageManager.import_image()"""
 
         mock_create.return_value = self.fake_image
@@ -264,24 +266,20 @@ class TestManage(TestCase):
         mock_get_image.reset_mock()
 
         # test the same function for image with 'file://' url
+        # file:// now imports via glance-direct so the raw conversion runs
 
-        # use a dedicated MagicMock for the image object because the
-        # implementation will call the upload() function on it
         mock_image_obj = mock.MagicMock()
         mock_image_obj.status = "active"
         mock_create.return_value = mock_image_obj
         mock_get_image.return_value = mock_image_obj
-        fake_file_buffer = mock.MagicMock()
-        mock_open.return_value = fake_file_buffer
 
         self.sot.import_image(
             self.file_image_dict, self.fake_name, self.file_url, self.file_versions, "1"
         )
 
         mock_create.assert_called_once_with(**properties)
-        self.assertEqual(mock_image_obj.data, fake_file_buffer)
-        mock_import.assert_not_called()
-        mock_image_obj.upload.assert_called_with(self.sot.conn.image)
+        mock_stage.assert_called_once_with(mock_image_obj, filename="/path/to/file.img")
+        mock_import.assert_called_once_with(mock_image_obj, method="glance-direct")
         mock_get_image.assert_called_once_with(mock_image_obj)
 
     @mock.patch("openstack_image_manager.main.time.sleep")


### PR DESCRIPTION
## What

The `file://` branch of `import_image()` uploaded the local file with the legacy
image data API (`new_image.upload()`), which bypasses Glance's interoperable image
import and its plugins. This switches it to the `glance-direct` import method, so a
local-file import runs the same decompress/convert/store taskflow as web-download.

Reuses the `_glance_direct_import()` helper from #1252; stacked on
`prefetch-on-stuck` until that merges.

## Why it matters

Where the import plugins convert images to raw (OSISM's Ceph/RBD setup), the legacy
upload stored a `file://` image in its original format. A non-raw image in the RBD
glance store cannot be COW-cloned, so nova downloads and converts it to raw per
instance on compute-local disk — slower, more space, and able to fail in RBD-only
or space-constrained setups. glance-direct produces a raw, COW-cloneable image.

## Compatibility

glance-direct is a long-standing, default-enabled Glance import method — nothing in
kolla or the OSISM overlays overrides `enabled_import_methods` — and it uses the
same staging store web-download already relies on
(`/var/lib/glance/staging`). So on any deployment where web-download works today,
this needs nothing new, and it has been stable in Glance since well before any
OSISM-supported release.

glance-direct applies the deployment's configured import plugins, so the stored
image differs from the legacy path only where conversion or decompression is
enabled — i.e. exactly where that transformation is intended. No OSISM flow imports
via `file://` today (octavia, clusterapi, gardenlinux and `manage images` all use
`http(s)` sources), so within OSISM this is effectively inert; it matters mainly to
the standalone PyPI package.

## Related

- osism/issues#1411

🤖 Generated with [Claude Code](https://claude.com/claude-code)
