### PR TITLE
Add detect-and-flag job for pending image-catalog updates

### DIFF
--- a/.github/workflows/check-updates.yml
+++ b/.github/workflows/check-updates.yml
@@ -1,0 +1,61 @@
+---
+name: Check image updates
+
+"on":
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 1'
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check-updates:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      LABEL: pending-image-updates
+      TITLE: Pending image catalog updates
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+      - run: pip3 install tox
+
+      - name: Run check
+        run: tox -e check-updates -- --output report.md --status-file status.txt
+        continue-on-error: true
+
+      - name: Reconcile issue
+        run: |
+          set -euo pipefail
+          if [ ! -f status.txt ]; then
+            echo "::error::check_updates did not complete (no status file)"
+            exit 1
+          fi
+          STATUS=$(tr -d '[:space:]' < status.txt)
+
+          gh label create "$LABEL" \
+            --description "Pending image catalog updates" --color FBCA04 \
+            --force >/dev/null 2>&1 || true
+
+          NUM=$(gh issue list --state open --label "$LABEL" \
+            --json number --jq '.[0].number // empty')
+
+          if [ "$STATUS" = "findings" ]; then
+            if [ -n "$NUM" ]; then
+              gh issue edit "$NUM" --body-file report.md
+            else
+              gh issue create --title "$TITLE" --label "$LABEL" --body-file report.md
+            fi
+          elif [ "$STATUS" = "clean" ]; then
+            if [ -n "$NUM" ]; then
+              gh issue close "$NUM" \
+                --comment "No pending catalog updates — closing automatically."
+            fi
+          else
+            echo "::error::unexpected status: $STATUS"
+            exit 1
+          fi

--- a/contrib/check_updates.py
+++ b/contrib/check_updates.py
@@ -1,0 +1,172 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Detect-and-flag: compare the image catalog against endoflife.date and report
+# supported majors not yet defined + enabled images past end-of-life.
+
+import datetime
+import os
+from dataclasses import dataclass, field
+
+import yaml
+
+ENDOFLIFE_API = "https://endoflife.date/api/{product}.json"
+HTTP_TIMEOUT = 30
+
+
+class EvaluationError(Exception):
+    """A data-integrity violation that must abort with operational-failure status."""
+
+
+@dataclass(frozen=True)
+class DistroConfig:
+    product: str
+    lts_only: bool = False
+
+
+# Keyed by etc/images/<key>.yml basename (not meta.os_distro, which is unreliable).
+DISTROS = {
+    "ubuntu": DistroConfig("ubuntu", lts_only=True),
+    "debian": DistroConfig("debian"),
+    "almalinux": DistroConfig("almalinux"),
+    "rockylinux": DistroConfig("rocky-linux"),
+    "centos": DistroConfig("centos-stream"),
+    "opensuse": DistroConfig("opensuse"),
+}
+
+
+@dataclass
+class CatalogEntry:
+    defined: set = field(default_factory=set)
+    enabled: set = field(default_factory=set)
+
+
+@dataclass
+class Finding:
+    distro: str
+    cycle: str
+    release_date: str
+    eol_text: str
+
+
+@dataclass
+class Report:
+    new_majors: list = field(default_factory=list)
+    eol: list = field(default_factory=list)
+
+    def is_empty(self):
+        return not self.new_majors and not self.eol
+
+
+def parse_eol(raw):
+    # Normalize the endoflife 'eol' field into a state.
+    # Returns ("date", date) | ("not_announced", None) | ("already_eol", None).
+    if raw is False:
+        return ("not_announced", None)
+    if raw is True:
+        return ("already_eol", None)
+    if isinstance(raw, str):
+        return ("date", datetime.date.fromisoformat(raw))
+    raise EvaluationError(f"unexpected eol value: {raw!r}")
+
+
+def read_catalog(images_dir):
+    catalog = {}
+    for distro in DISTROS:
+        path = os.path.join(images_dir, f"{distro}.yml")
+        if not os.path.exists(path):
+            # A configured mapping file must exist. Missing = anomaly (deleted or
+            # renamed), not a reason to silently shrink the evaluated set — which
+            # could otherwise report clean and close the tracking issue.
+            raise EvaluationError(f"missing catalog file: {path}")
+        with open(path) as fp:
+            data = yaml.safe_load(fp)
+        cat = CatalogEntry()
+        for image in data.get("images", []):
+            version = str(image.get("meta", {}).get("os_version", "")).strip()
+            if not version:
+                continue
+            cat.defined.add(version)
+            if image.get("enable", True):
+                cat.enabled.add(version)
+        catalog[distro] = cat
+    return catalog
+
+
+def _released(cycle, today):
+    rel = cycle.get("releaseDate")
+    return isinstance(rel, str) and datetime.date.fromisoformat(rel) <= today
+
+
+def _eol_text(state, day):
+    if state == "date":
+        return day.isoformat()
+    if state == "not_announced":
+        return "not announced"
+    return "date unknown"  # already_eol
+
+
+def evaluate(catalog, products_data, today):
+    report = Report()
+    for distro, cfg in DISTROS.items():
+        entry = catalog.get(distro)
+        if entry is None:
+            continue
+        cycles = products_data.get(cfg.product)
+        if not cycles:
+            raise EvaluationError(f"no data for product {cfg.product}")
+        by_cycle = {str(c["cycle"]): c for c in cycles}
+
+        supported = set()
+        for c in cycles:
+            if not _released(c, today):
+                continue
+            state, day = parse_eol(c.get("eol"))
+            if state == "already_eol" or (state == "date" and day <= today):
+                continue
+            if cfg.lts_only and not c.get("lts"):
+                continue
+            supported.add(str(c["cycle"]))
+
+        if not supported:
+            raise EvaluationError(f"product {cfg.product} returned no supported cycles")
+
+        for cyc in sorted(supported - entry.defined):
+            c = by_cycle[cyc]
+            state, day = parse_eol(c.get("eol"))
+            report.new_majors.append(
+                Finding(distro, cyc, c.get("releaseDate"), _eol_text(state, day))
+            )
+
+        for cyc in sorted(entry.enabled):
+            c = by_cycle.get(cyc)
+            if c is None:
+                raise EvaluationError(f"enabled {distro} {cyc} not found upstream")
+            state, day = parse_eol(c.get("eol"))
+            if state == "already_eol" or (state == "date" and day <= today):
+                report.eol.append(
+                    Finding(distro, cyc, c.get("releaseDate"), _eol_text(state, day))
+                )
+    return report
+
+
+def render_markdown(report):
+    lines = []
+    if report.new_majors:
+        lines += ["## New versions available", ""]
+        for f in report.new_majors:
+            lines.append(
+                f"- **{f.distro}**: {f.cycle} "
+                f"(released {f.release_date}, EOL {f.eol_text})"
+            )
+        lines.append("")
+    if report.eol:
+        lines += ["## End-of-life images", ""]
+        for f in report.eol:
+            when = (
+                "(date unknown)" if f.eol_text == "date unknown" else f"on {f.eol_text}"
+            )
+            lines.append(
+                f"- **{f.distro}**: {f.cycle} reached EOL {when} (still enabled)"
+            )
+        lines.append("")
+    return ("\n".join(lines).strip() + "\n") if lines else ""

--- a/contrib/check_updates.py
+++ b/contrib/check_updates.py
@@ -27,12 +27,17 @@ class EvaluationError(Exception):
 class DistroConfig:
     product: str
     lts_only: bool = False
+    # Which endoflife field marks the end of *free* support. Default 'eol'. Debian's
+    # 'eol' is only the end of regular support; its free community LTS runs on until
+    # 'extendedSupport', which is when a Debian release is truly retired. (Ubuntu's
+    # 'extendedSupport' is *paid* ESM, so Ubuntu deliberately stays on 'eol'.)
+    eol_field: str = "eol"
 
 
 # Keyed by etc/images/<key>.yml basename (not meta.os_distro, which is unreliable).
 DISTROS = {
     "ubuntu": DistroConfig("ubuntu", lts_only=True),
-    "debian": DistroConfig("debian"),
+    "debian": DistroConfig("debian", eol_field="extendedSupport"),
     "almalinux": DistroConfig("almalinux"),
     "rockylinux": DistroConfig("rocky-linux"),
     "centos": DistroConfig("centos-stream"),
@@ -126,7 +131,7 @@ def evaluate(catalog, products_data, today):
         for c in cycles:
             if not _released(c, today):
                 continue
-            state, day = parse_eol(c.get("eol"))
+            state, day = parse_eol(c.get(cfg.eol_field))
             if state == "already_eol" or (state == "date" and day <= today):
                 continue
             if cfg.lts_only and not c.get("lts"):
@@ -138,7 +143,7 @@ def evaluate(catalog, products_data, today):
 
         for cyc in sorted(supported - entry.defined):
             c = by_cycle[cyc]
-            state, day = parse_eol(c.get("eol"))
+            state, day = parse_eol(c.get(cfg.eol_field))
             report.new_majors.append(
                 Finding(distro, cyc, c.get("releaseDate"), _eol_text(state, day))
             )
@@ -147,7 +152,7 @@ def evaluate(catalog, products_data, today):
             c = by_cycle.get(cyc)
             if c is None:
                 raise EvaluationError(f"enabled {distro} {cyc} not found upstream")
-            state, day = parse_eol(c.get("eol"))
+            state, day = parse_eol(c.get(cfg.eol_field))
             if state == "already_eol" or (state == "date" and day <= today):
                 report.eol.append(
                     Finding(distro, cyc, c.get("releaseDate"), _eol_text(state, day))

--- a/contrib/check_updates.py
+++ b/contrib/check_updates.py
@@ -5,9 +5,15 @@
 
 import datetime
 import os
+import sys
 from dataclasses import dataclass, field
 
+import requests
+import typer
 import yaml
+from loguru import logger
+
+app = typer.Typer()
 
 ENDOFLIFE_API = "https://endoflife.date/api/{product}.json"
 HTTP_TIMEOUT = 30
@@ -170,3 +176,57 @@ def render_markdown(report):
             )
         lines.append("")
     return ("\n".join(lines).strip() + "\n") if lines else ""
+
+
+def fetch_product(product):
+    resp = requests.get(ENDOFLIFE_API.format(product=product), timeout=HTTP_TIMEOUT)
+    resp.raise_for_status()
+    return resp.json()
+
+
+@app.command()
+def main(
+    images_dir: str = typer.Option(
+        "etc/images", help="Directory with image definitions"
+    ),
+    today: str = typer.Option(None, help="Reference date YYYY-MM-DD (default: today)"),
+    output: str = typer.Option(
+        None, help="Write the markdown report here (default: stdout)"
+    ),
+    status_file: str = typer.Option(
+        None, help="Write completion sentinel (clean|findings) here, last, on success"
+    ),
+    debug: bool = typer.Option(False, help="Enable debug logging"),
+):
+    logger.remove()
+    logger.add(sys.stderr, level="DEBUG" if debug else "INFO")
+
+    try:
+        ref = datetime.date.fromisoformat(today) if today else datetime.date.today()
+        catalog = read_catalog(images_dir)
+        products = {cfg.product for name, cfg in DISTROS.items() if name in catalog}
+        products_data = {p: fetch_product(p) for p in products}
+        report = evaluate(catalog, products_data, ref)
+        markdown = render_markdown(report)
+    except typer.Exit:
+        raise
+    except Exception as e:  # noqa: BLE001 - any failure is operational, exit 2
+        logger.error(f"operational failure: {e}")
+        raise typer.Exit(code=2)
+
+    if output:
+        with open(output, "w") as fp:
+            fp.write(markdown)
+    else:
+        sys.stdout.write(markdown)
+
+    status = "clean" if report.is_empty() else "findings"
+    if status_file:  # written LAST, only after everything above succeeded
+        with open(status_file, "w") as fp:
+            fp.write(status + "\n")
+
+    raise typer.Exit(code=0 if report.is_empty() else 1)
+
+
+if __name__ == "__main__":
+    app()

--- a/test/unit/test_check_updates.py
+++ b/test/unit/test_check_updates.py
@@ -171,5 +171,69 @@ class ReadCatalogTest(unittest.TestCase):
             shutil.rmtree(d)
 
 
+from unittest import mock  # noqa: E402
+
+import typer  # noqa: E402
+
+
+class MainExitTest(unittest.TestCase):
+    def setUp(self):
+        self.dir = tempfile.mkdtemp()
+        self.out = os.path.join(self.dir, "report.md")
+        self.status = os.path.join(self.dir, "status.txt")
+
+    def tearDown(self):
+        shutil.rmtree(self.dir)
+
+    @staticmethod
+    def _read(path):
+        with open(path) as fp:
+            return fp.read()
+
+    def _run(self, catalog, **fetch_kw):
+        # Mock read_catalog (tested on its own in ReadCatalogTest) so this
+        # isolates the exit-code / sentinel plumbing. main() raises typer.Exit
+        # (a RuntimeError subclass with .exit_code, NOT a SystemExit) when called
+        # directly, bypassing the Typer runtime.
+        with mock.patch.object(
+            cu, "read_catalog", return_value=catalog
+        ), mock.patch.object(cu, "fetch_product", **fetch_kw):
+            try:
+                cu.main(
+                    images_dir=self.dir,
+                    today="2026-06-01",
+                    output=self.out,
+                    status_file=self.status,
+                    debug=False,
+                )
+                return 0
+            except typer.Exit as e:
+                return e.exit_code
+
+    def test_findings_exit_1_and_sentinel(self):
+        code = self._run({"ubuntu": entry(["22.04", "24.04"])}, return_value=UBUNTU)
+        self.assertEqual(code, 1)
+        self.assertEqual(self._read(self.status).strip(), "findings")
+        self.assertIn("26.04", self._read(self.out))
+
+    def test_clean_exit_0_and_sentinel(self):
+        product = [
+            {
+                "cycle": "24.04",
+                "releaseDate": "2024-04-25",
+                "eol": "2029-04-25",
+                "lts": True,
+            },
+        ]
+        code = self._run({"ubuntu": entry(["24.04"])}, return_value=product)
+        self.assertEqual(code, 0)
+        self.assertEqual(self._read(self.status).strip(), "clean")
+
+    def test_operational_failure_exit_2_no_sentinel(self):
+        code = self._run({"ubuntu": entry(["24.04"])}, side_effect=RuntimeError("boom"))
+        self.assertEqual(code, 2)
+        self.assertFalse(os.path.exists(self.status))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/unit/test_check_updates.py
+++ b/test/unit/test_check_updates.py
@@ -1,0 +1,175 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import datetime
+import os
+import shutil
+import tempfile
+import unittest
+
+import contrib.check_updates as cu
+
+TODAY = datetime.date(2026, 6, 1)
+
+UBUNTU = [
+    {"cycle": "26.04", "releaseDate": "2026-04-23", "eol": "2031-04-30", "lts": True},
+    {"cycle": "25.10", "releaseDate": "2025-10-09", "eol": "2026-07-01", "lts": False},
+    {"cycle": "24.04", "releaseDate": "2024-04-25", "eol": "2029-04-25", "lts": True},
+    {"cycle": "22.04", "releaseDate": "2022-04-21", "eol": "2027-04-01", "lts": True},
+]
+OPENSUSE = [
+    {"cycle": "16.0", "releaseDate": "2025-10-01", "eol": "2027-10-31", "lts": None},
+    {"cycle": "15.6", "releaseDate": "2024-06-12", "eol": "2026-04-30", "lts": None},
+]
+DEBIAN = [
+    {"cycle": "13", "releaseDate": "2025-08-09", "eol": "2028-08-09", "lts": True},
+    {"cycle": "12", "releaseDate": "2023-06-10", "eol": "2028-06-30", "lts": True},
+]
+
+
+def entry(defined, enabled=None):
+    return cu.CatalogEntry(
+        defined=set(defined), enabled=set(enabled if enabled is not None else defined)
+    )
+
+
+class EvaluateTest(unittest.TestCase):
+    def test_ubuntu_lts_filter(self):
+        catalog = {"ubuntu": entry(["22.04", "24.04"])}
+        report = cu.evaluate(catalog, {"ubuntu": UBUNTU}, TODAY)
+        cycles = {f.cycle for f in report.new_majors}
+        self.assertEqual(cycles, {"26.04"})  # not 25.10 (non-LTS), not 25.04
+
+    def test_opensuse_both_signals(self):
+        catalog = {"opensuse": entry(["15.6"])}
+        report = cu.evaluate(catalog, {"opensuse": OPENSUSE}, TODAY)
+        self.assertEqual({f.cycle for f in report.new_majors}, {"16.0"})
+        self.assertEqual({f.cycle for f in report.eol}, {"15.6"})
+
+    def test_clean_distro(self):
+        catalog = {"debian": entry(["12", "13"])}
+        report = cu.evaluate(catalog, {"debian": DEBIAN}, TODAY)
+        self.assertTrue(report.is_empty())
+
+    def test_disabled_not_eol_flagged(self):
+        # 15.6 defined but disabled -> no EOL finding; 16.0 still a new major.
+        catalog = {"opensuse": entry(["15.6"], enabled=[])}
+        report = cu.evaluate(catalog, {"opensuse": OPENSUSE}, TODAY)
+        self.assertEqual(report.eol, [])
+        self.assertEqual({f.cycle for f in report.new_majors}, {"16.0"})
+
+    def test_future_release_not_flagged(self):
+        product = [
+            {
+                "cycle": "24.04",
+                "releaseDate": "2024-04-25",
+                "eol": "2029-04-25",
+                "lts": True,
+            },
+            {
+                "cycle": "99.04",
+                "releaseDate": "2027-01-01",
+                "eol": "2032-01-01",
+                "lts": True,
+            },
+        ]
+        catalog = {"ubuntu": entry(["24.04"])}
+        report = cu.evaluate(catalog, {"ubuntu": product}, TODAY)
+        self.assertEqual(report.new_majors, [])  # 99.04 unreleased
+
+    def test_boolean_eol_both_values(self):
+        product = [
+            {"cycle": "a", "releaseDate": "2020-01-01", "eol": False, "lts": True},
+            {"cycle": "b", "releaseDate": "2019-01-01", "eol": True, "lts": True},
+        ]
+        catalog = {"ubuntu": entry(["b"])}  # b defined+enabled
+        report = cu.evaluate(catalog, {"ubuntu": product}, TODAY)
+        self.assertEqual({f.cycle for f in report.new_majors}, {"a"})
+        self.assertEqual({f.cycle for f in report.eol}, {"b"})
+        eol_a = next(f for f in report.new_majors if f.cycle == "a")
+        self.assertIn("not announced", eol_a.eol_text)
+        eol_b = next(f for f in report.eol if f.cycle == "b")
+        self.assertIn("unknown", eol_b.eol_text)
+
+    def test_validation_no_supported_cycles(self):
+        product = [
+            {
+                "cycle": "old",
+                "releaseDate": "2000-01-01",
+                "eol": "2005-01-01",
+                "lts": True,
+            }
+        ]
+        catalog = {"ubuntu": entry(["old"])}
+        with self.assertRaises(cu.EvaluationError):
+            cu.evaluate(catalog, {"ubuntu": product}, TODAY)
+
+    def test_validation_enabled_cycle_missing_upstream(self):
+        catalog = {"ubuntu": entry(["77.04"])}  # not in UBUNTU
+        with self.assertRaises(cu.EvaluationError):
+            cu.evaluate(catalog, {"ubuntu": UBUNTU}, TODAY)
+
+
+class ParseEolTest(unittest.TestCase):
+    def test_date(self):
+        self.assertEqual(
+            cu.parse_eol("2027-04-01"), ("date", datetime.date(2027, 4, 1))
+        )
+
+    def test_not_announced(self):
+        self.assertEqual(cu.parse_eol(False), ("not_announced", None))
+
+    def test_already_eol(self):
+        self.assertEqual(cu.parse_eol(True), ("already_eol", None))
+
+
+class RenderTest(unittest.TestCase):
+    def test_both_sections(self):
+        report = cu.Report(
+            new_majors=[cu.Finding("ubuntu", "26.04", "2026-04-23", "2031-04-30")],
+            eol=[cu.Finding("opensuse", "15.6", "2024-06-12", "2026-04-30")],
+        )
+        md = cu.render_markdown(report)
+        self.assertIn("## New versions available", md)
+        self.assertIn("## End-of-life images", md)
+        self.assertIn("**ubuntu**: 26.04", md)
+        self.assertIn("**opensuse**: 15.6", md)
+
+    def test_empty(self):
+        self.assertEqual(
+            cu.render_markdown(cu.Report(new_majors=[], eol=[])).strip(), ""
+        )
+
+
+class ReadCatalogTest(unittest.TestCase):
+    def _write_minimal(self, directory, name):
+        with open(os.path.join(directory, f"{name}.yml"), "w") as fp:
+            fp.write(
+                "---\nimages:\n  - name: X\n    enable: true\n"
+                "    shortname: x\n    meta:\n      os_version: '1'\n"
+            )
+
+    def test_missing_mapped_file_raises(self):
+        # A mapped file absent is an anomaly, not "skip" — must raise so the run
+        # cannot report clean and close the issue.
+        d = tempfile.mkdtemp()
+        try:
+            self._write_minimal(d, "ubuntu")  # the other five are missing
+            with self.assertRaises(cu.EvaluationError):
+                cu.read_catalog(d)
+        finally:
+            shutil.rmtree(d)
+
+    def test_all_present_returns_all(self):
+        d = tempfile.mkdtemp()
+        try:
+            for name in cu.DISTROS:
+                self._write_minimal(d, name)
+            catalog = cu.read_catalog(d)
+            self.assertEqual(set(catalog), set(cu.DISTROS))
+            self.assertEqual(catalog["ubuntu"].enabled, {"1"})
+        finally:
+            shutil.rmtree(d)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unit/test_check_updates.py
+++ b/test/unit/test_check_updates.py
@@ -21,8 +21,21 @@ OPENSUSE = [
     {"cycle": "15.6", "releaseDate": "2024-06-12", "eol": "2026-04-30", "lts": None},
 ]
 DEBIAN = [
-    {"cycle": "13", "releaseDate": "2025-08-09", "eol": "2028-08-09", "lts": True},
-    {"cycle": "12", "releaseDate": "2023-06-10", "eol": "2028-06-30", "lts": True},
+    # Debian is evaluated on 'extendedSupport' (free LTS end), not 'eol'.
+    {
+        "cycle": "13",
+        "releaseDate": "2025-08-09",
+        "eol": "2028-08-09",
+        "extendedSupport": "2030-06-30",
+        "lts": True,
+    },
+    {
+        "cycle": "12",
+        "releaseDate": "2023-06-10",
+        "eol": "2026-07-11",
+        "extendedSupport": "2028-06-30",
+        "lts": True,
+    },
 ]
 
 
@@ -56,6 +69,31 @@ class EvaluateTest(unittest.TestCase):
         report = cu.evaluate(catalog, {"opensuse": OPENSUSE}, TODAY)
         self.assertEqual(report.eol, [])
         self.assertEqual({f.cycle for f in report.new_majors}, {"16.0"})
+
+    def test_debian_free_lts_not_eol_flagged(self):
+        # For Debian, endoflife 'eol' = end of regular support; free community
+        # LTS runs later via 'extendedSupport'. A cycle past 'eol' but within
+        # extendedSupport must NOT be flagged EOL (it is still freely supported).
+        product = [
+            {
+                "cycle": "13",
+                "releaseDate": "2025-08-09",
+                "eol": "2028-08-09",
+                "extendedSupport": "2030-06-30",
+                "lts": True,
+            },
+            {
+                "cycle": "12",
+                "releaseDate": "2023-06-10",
+                "eol": "2025-01-01",  # regular support already ended
+                "extendedSupport": "2028-06-30",  # but LTS still active
+                "lts": True,
+            },
+        ]
+        report = cu.evaluate(
+            {"debian": entry(["12", "13"])}, {"debian": product}, TODAY
+        )
+        self.assertTrue(report.is_empty())
 
     def test_future_release_not_flagged(self):
         product = [

--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,10 @@ commands =
 commands =
     python contrib/update.py {posargs}
 
+[testenv:check-updates]
+commands =
+    python contrib/check_updates.py {posargs}
+
 [testenv:update-gardenlinux]
 commands =
     python contrib/update-gardenlinux.py


### PR DESCRIPTION
## What

A scheduled, read-only job that compares the image catalog against endoflife.date and flags — in a single auto-maintained GitHub issue — supported upstream majors the catalog does not define yet, and enabled images that are past end of life.

- `contrib/check_updates.py` — reads `etc/images/*.yml`, queries endoflife.date per distribution, and reports new majors + end-of-life images. Pure evaluation logic with a three-state exit contract (`0` clean / `1` findings / `2` operational failure) and a `status.txt` completion sentinel written last, so a crash or fetch error can never be mistaken for "clean" (which would wrongly close the issue).
- `.github/workflows/check-updates.yml` — runs weekly, reconciles one issue (label `pending-image-updates`) off the sentinel: create/update on findings, close when clean, and leave the issue untouched on operational failure.
- Per-distribution EOL semantics: Debian is evaluated on `extendedSupport` (its free community LTS), everyone else on `eol` (Ubuntu's `extendedSupport` is paid ESM), so LTS-active Debian releases are not wrongly flagged.

## Testing

- `tox -e test -- test/unit test_check_updates.py` — 19 tests: Ubuntu LTS filter, openSUSE both-signals, clean distro, disabled-not-EOL, future-release, boolean `eol`, data-integrity validation → exit 2, completion sentinel, markdown render.
- Verified live against endoflife.date: reports the expected new majors plus EOL openSUSE Leap 15.6; the operational-failure path exits 2 and writes no sentinel.
- flake8 / black / mypy / yamllint clean.

## Notes

Independent of the `update.py` cleanup/refactor work. The `gh`-issue reconciliation is only fully exercised on a real scheduled run.

Surfaces the kind of drift tracked in:

- osism/issues#1417

🤖 Generated with [Claude Code](https://claude.com/claude-code)