### PR TITLE
Skip disabled images in update.py

### DIFF
--- a/contrib/update.py
+++ b/contrib/update.py
@@ -228,6 +228,9 @@ def main(
 
         updates = 0
         for image in data["images"]:
+            if not image.get("enable", True):
+                logger.info(f"Skipping disabled image {image['name']}")
+                continue
             if "latest_url" not in image:
                 continue
             updates += update_image(image, handler)

--- a/test/unit/test_update.py
+++ b/test/unit/test_update.py
@@ -81,6 +81,19 @@ class WriteContractTest(unittest.TestCase):
         after = self._read()
         self.assertEqual(before, after)
 
+    def test_disabled_image_not_updated(self):
+        # A disabled image must not be refreshed even when upstream changed.
+        with open(self.path, "w") as fp:
+            fp.write(SAMPLE_YML.replace("enable: true", "enable: false"))
+        before = self._read()
+        fake = _FakeHandler(
+            ("sha256:" + "1" * 64, "https://example.test/example.qcow2", "20260101")
+        )
+        with mock.patch.dict(update.HANDLERS, {"example": fake}, clear=True):
+            update.main(name="example", debug=False, dry_run=False, images_dir=self.dir)
+        after = self._read()
+        self.assertEqual(before, after)
+
 
 FIXTURES = os.path.join(os.path.dirname(__file__), "fixtures", "update")
 DATED_UBUNTU = "20260705"


### PR DESCRIPTION
## What

Skip disabled images in `contrib/update.py` so the weekly update run no
longer refreshes images whose `enable` flag is explicitly `false`.

## Why

The updater refreshed every image carrying a `latest_url`, ignoring the
`enable` flag. Disabled, end-of-life images were therefore still updated
and showed up in the generated pull requests — e.g. Ubuntu 20.04 was
bumped to a 2025 build long after being disabled.

## How

Skip images with `enable: false` in the main loop, before any upstream
fetch. A missing `enable` still defaults to enabled, matching how the
manager (`openstack_image_manager/main.py`) treats the field. This aligns
the updater with the manager: an image that is not served is also not
refreshed, and its definition stays frozen at its last version.

## Tests

A `WriteContractTest` case covers it: a disabled image with a changed
upstream checksum leaves the YAML file untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
