### PR TITLE
Add current major versions to image catalog

### DIFF
--- a/.github/workflows/update-images.yml
+++ b/.github/workflows/update-images.yml
@@ -15,6 +15,7 @@ jobs:
           - almalinux
           - centos
           - debian
+          - opensuse
           - rockylinux
           - ubuntu
 

--- a/contrib/mirror.py
+++ b/contrib/mirror.py
@@ -103,6 +103,7 @@ def main(
                 "debian",
                 "flatcar",
                 "gardenlinux",
+                "opensuse",
                 "opnsense",
                 "rocky",
                 "talos",

--- a/contrib/update.py
+++ b/contrib/update.py
@@ -44,6 +44,7 @@ MIRROR_DIR_CONFIG = {
     "centos-stream-9": MirrorDirConfig(checksum_style="bsd", resolve_latest=True),
     "rocky-8": MirrorDirConfig(checksum_style="bsd", bsd_key="target"),
     "rocky-9": MirrorDirConfig(checksum_style="bsd", bsd_key="target"),
+    "rocky-10": MirrorDirConfig(checksum_style="bsd", bsd_key="target"),
 }
 
 

--- a/contrib/update.py
+++ b/contrib/update.py
@@ -135,6 +135,7 @@ HANDLERS = {
     "almalinux": MirrorDirHandler(),
     "centos": MirrorDirHandler(),
     "debian": DirListingHandler(),
+    "opensuse": MirrorDirHandler(),
     "rockylinux": MirrorDirHandler(),
     "ubuntu": DirListingHandler(),
 }

--- a/contrib/update.py
+++ b/contrib/update.py
@@ -42,6 +42,7 @@ MIRROR_DIR_CONFIG = {
     "centos-7": MirrorDirConfig(checksum_style="plain", resolve_latest=True),
     "centos-stream-8": MirrorDirConfig(checksum_style="bsd", resolve_latest=True),
     "centos-stream-9": MirrorDirConfig(checksum_style="bsd", resolve_latest=True),
+    "centos-stream-10": MirrorDirConfig(checksum_style="bsd", resolve_latest=True),
     "rocky-8": MirrorDirConfig(checksum_style="bsd", bsd_key="target"),
     "rocky-9": MirrorDirConfig(checksum_style="bsd", bsd_key="target"),
     "rocky-10": MirrorDirConfig(checksum_style="bsd", bsd_key="target"),

--- a/etc/images/almalinux.yml
+++ b/etc/images/almalinux.yml
@@ -74,3 +74,40 @@ images:
         checksum: 
           sha256:5ff9c048859046f41db4a33b1f1a96675711288078aac66b47d0be023af270d1
         build_date: 2025-11-18
+  - name: AlmaLinux 10
+    enable: true
+    shortname: almalinux-10
+    format: qcow2
+    login: almalinux
+    min_disk: 10
+    min_ram: 512
+    status: active
+    visibility: public
+    multi: true
+    meta:
+      architecture: x86_64
+      hw_disk_bus: scsi
+      hw_rng_model: virtio
+      hw_scsi_model: virtio-scsi
+      hw_watchdog_action: reset
+      hypervisor_type: qemu
+      os_distro: centos
+      os_version: '10'
+      os_purpose: generic
+      replace_frequency: quarterly
+      uuid_validity: last-3
+      provided_until: none
+    tags: []
+    latest_checksum_url:
+      https://repo.almalinux.org/almalinux/10/cloud/x86_64/images/CHECKSUM
+    latest_url:
+      https://repo.almalinux.org/almalinux/10/cloud/x86_64/images/AlmaLinux-10-GenericCloud-latest.x86_64.qcow2
+    versions:
+      - version: '20260526'
+        url:
+          https://repo.almalinux.org/almalinux/10/cloud/x86_64/images/AlmaLinux-10-GenericCloud-latest.x86_64.qcow2
+        mirror_url:
+          https://nbg1.your-objectstorage.com/osism/openstack-images/almalinux-10/20260526-almalinux-10.qcow2
+        checksum:
+          sha256:47f2218668dd4776be140dd92fa3bea700be1766e2c7d88bdfd6a4b50f477b4d
+        build_date: 2026-05-26

--- a/etc/images/centos.yml
+++ b/etc/images/centos.yml
@@ -110,3 +110,40 @@ images:
         checksum: 
           sha256:4754fa55d85b3a487651f18940b389cef055d1436432dd01b1d059d0b879f141
         build_date: 2026-01-20
+  - name: CentOS Stream 10
+    enable: true
+    shortname: centos-stream-10
+    format: qcow2
+    login: centos
+    min_disk: 10
+    min_ram: 512
+    status: active
+    visibility: public
+    multi: true
+    meta:
+      architecture: x86_64
+      hw_disk_bus: scsi
+      hw_rng_model: virtio
+      hw_scsi_model: virtio-scsi
+      hw_watchdog_action: reset
+      hypervisor_type: qemu
+      os_distro: centos
+      os_version: '10'
+      os_purpose: generic
+      replace_frequency: quarterly
+      uuid_validity: last-3
+      provided_until: none
+    tags: []
+    latest_checksum_url: 
+      https://cloud.centos.org/centos/10-stream/x86_64/images/CHECKSUM
+    latest_url: 
+      https://cloud.centos.org/centos/10-stream/x86_64/images/CentOS-Stream-GenericCloud-10-HEREBE\d+\.\dDRAGONS.x86_64.qcow2
+    versions:
+      - version: '20260902'
+        url: 
+          https://cloud.centos.org/centos/10-stream/x86_64/images/CentOS-Stream-GenericCloud-10-20260901.0.x86_64.qcow2
+        mirror_url: 
+          https://nbg1.your-objectstorage.com/osism/openstack-images/centos-stream-10/20260902-centos-stream-10.qcow2
+        checksum: 
+          sha256:d33095d9bb4b3f5a168794b92f174e5e71c031210e63ef75bfd91d9d13a7de01
+        build_date: 2026-09-02

--- a/etc/images/opensuse.yml
+++ b/etc/images/opensuse.yml
@@ -1,7 +1,7 @@
 ---
 images:
   - name: openSUSE Leap 15.6
-    enable: true
+    enable: false
     shortname: opensuse-leap-15.6
     format: qcow2
     login: opensuse

--- a/etc/images/opensuse.yml
+++ b/etc/images/opensuse.yml
@@ -31,3 +31,34 @@ images:
           https://nbg1.your-objectstorage.com/osism/openstack-images/opensuse-leap-15.6/20240603-openSUSE-Leap-15.6-Minimal-VM.x86_64-Cloud.qcow2
         checksum: "sha256:0f7f09a9a083088b51aa365fe0e4310e6b156c2153d6aa03a77b81eee884e52a"
         build_date: 2024-06-03
+  - name: openSUSE Leap 16.0
+    enable: true
+    shortname: opensuse-leap-16.0
+    format: qcow2
+    login: sles
+    min_disk: 10
+    min_ram: 512
+    status: active
+    visibility: public
+    multi: true
+    meta:
+      architecture: x86_64
+      hw_disk_bus: scsi
+      hw_rng_model: virtio
+      hw_scsi_model: virtio-scsi
+      hw_watchdog_action: reset
+      hypervisor_type: qemu
+      os_distro: opensuse
+      os_version: '16.0'
+      os_purpose: generic
+      replace_frequency: quarterly
+      uuid_validity: last-3
+      provided_until: none
+    tags: []
+    versions:
+      - version: '20260618'
+        url: https://ftp.gwdg.de/pub/opensuse/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.x86_64-Cloud.qcow2
+        mirror_url:
+          https://nbg1.your-objectstorage.com/osism/openstack-images/opensuse-leap-16.0/20260618-opensuse-leap-16.0.qcow2
+        checksum: "sha256:c5cd6904632c86d5368dea3896da8c17571c238ef96a0e2c8b0ca1835d796e07"
+        build_date: 2026-06-18

--- a/etc/images/opensuse.yml
+++ b/etc/images/opensuse.yml
@@ -55,6 +55,10 @@ images:
       uuid_validity: last-3
       provided_until: none
     tags: []
+    latest_checksum_url:
+      https://ftp.gwdg.de/pub/opensuse/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.x86_64-Cloud.qcow2.sha256
+    latest_url:
+      https://ftp.gwdg.de/pub/opensuse/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.x86_64-Cloud.qcow2
     versions:
       - version: '20260618'
         url: https://ftp.gwdg.de/pub/opensuse/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.x86_64-Cloud.qcow2

--- a/etc/images/rockylinux.yml
+++ b/etc/images/rockylinux.yml
@@ -74,3 +74,40 @@ images:
         checksum: 
           sha256:15d81d3434b298142b2fdd8fb54aef2662684db5c082cc191c3c79762ed6360c
         build_date: 2025-11-23
+  - name: Rocky 10
+    enable: true
+    shortname: rocky-10
+    format: qcow2
+    login: rocky
+    min_disk: 10
+    min_ram: 512
+    status: active
+    visibility: public
+    multi: true
+    meta:
+      architecture: x86_64
+      hw_disk_bus: scsi
+      hw_rng_model: virtio
+      hw_scsi_model: virtio-scsi
+      hw_watchdog_action: reset
+      hypervisor_type: qemu
+      os_distro: rocky
+      os_version: '10'
+      os_purpose: generic
+      replace_frequency: quarterly
+      uuid_validity: last-3
+      provided_until: none
+    tags: []
+    latest_checksum_url:
+      https://download.rockylinux.org/pub/rocky/10/images/x86_64/Rocky-10-GenericCloud.latest.x86_64.qcow2.CHECKSUM
+    latest_url:
+      https://download.rockylinux.org/pub/rocky/10/images/x86_64/Rocky-10-GenericCloud.latest.x86_64.qcow2
+    versions:
+      - version: '20260526'
+        url:
+          https://download.rockylinux.org/pub/rocky/10/images/x86_64/Rocky-10-GenericCloud.latest.x86_64.qcow2
+        mirror_url:
+          https://nbg1.your-objectstorage.com/osism/openstack-images/rocky-10/20260526-rocky-10.qcow2
+        checksum:
+          sha256:9fc9e9ff16888bb68ac39b0392e25c9c92684d50c85f1cce6ab549363bbc4b48
+        build_date: 2026-05-26

--- a/etc/images/ubuntu.yml
+++ b/etc/images/ubuntu.yml
@@ -407,3 +407,77 @@ images:
         checksum: 
           sha256:a8f88520387bd1a4deedfdb958779c1cc1d088a310f9fa01cd380f0e3164fbc2
         build_date: 2026-01-05
+  - name: Ubuntu 26.04
+    enable: true
+    shortname: ubuntu-26.04
+    format: qcow2
+    login: ubuntu
+    min_disk: 8
+    min_ram: 512
+    status: active
+    visibility: public
+    multi: true
+    meta:
+      architecture: x86_64
+      hw_disk_bus: scsi
+      hw_rng_model: virtio
+      hw_scsi_model: virtio-scsi
+      hw_watchdog_action: reset
+      hypervisor_type: qemu
+      os_distro: ubuntu
+      os_version: '26.04'
+      os_purpose: generic
+      replace_frequency: quarterly
+      uuid_validity: last-3
+      provided_until: none
+    tags: []
+    latest_checksum_url:
+      https://cloud-images.ubuntu.com/resolute/current/SHA256SUMS
+    latest_url:
+      https://cloud-images.ubuntu.com/resolute/current/resolute-server-cloudimg-amd64.img
+    versions:
+      - version: '20260717'
+        url:
+          https://cloud-images.ubuntu.com/resolute/20260717/resolute-server-cloudimg-amd64.img
+        mirror_url:
+          https://nbg1.your-objectstorage.com/osism/openstack-images/ubuntu-26.04/20260717-ubuntu-26.04.qcow2
+        checksum:
+          sha256:b7daa0ffcb06acf44547a2f7682088d13acf0609937507faa8d7ef0302640ddd
+        build_date: 2026-07-17
+  - name: Ubuntu 26.04 Minimal
+    enable: true
+    shortname: ubuntu-26.04-minimal
+    format: qcow2
+    login: ubuntu
+    min_disk: 8
+    min_ram: 512
+    status: active
+    visibility: public
+    multi: true
+    meta:
+      architecture: x86_64
+      hw_disk_bus: scsi
+      hw_rng_model: virtio
+      hw_scsi_model: virtio-scsi
+      hw_watchdog_action: reset
+      hypervisor_type: qemu
+      os_distro: ubuntu
+      os_version: '26.04'
+      os_purpose: minimal
+      replace_frequency: quarterly
+      uuid_validity: last-3
+      provided_until: none
+    tags: []
+    latest_checksum_url:
+      https://cloud-images.ubuntu.com/minimal/releases/resolute/release/SHA256SUMS
+    latest_url:
+      https://cloud-images.ubuntu.com/minimal/releases/resolute/release/ubuntu-26.04-minimal-cloudimg-amd64.img
+    versions:
+      - version: '20260717'
+        url:
+          https://cloud-images.ubuntu.com/minimal/releases/resolute/release-20260717/ubuntu-26.04-minimal-cloudimg-amd64.img
+        mirror_url:
+          https://nbg1.your-objectstorage.com/osism/openstack-images/ubuntu-26.04-minimal/20260717-ubuntu-26.04-minimal.qcow2
+        checksum:
+          sha256:fe1deeb97031e27f929dca2472bb4ef30c38e33fa43eb2f721b20f12db1d0da1
+        build_date: 2026-07-17


### PR DESCRIPTION
Refresh the image catalog with the current major releases and make openSUSE
maintainable by the update tooling.

Part of the image-catalog refresh tracked in osism/issues#1417. It was stacked
on top of, and now targets `main` directly:

- osism/openstack-image-manager#1255
- osism/openstack-image-manager#1258

## New images

| Image | Released | Supported until |
| --- | --- | --- |
| AlmaLinux 10 | 2025-05-27 | 2035 |
| Ubuntu 26.04 LTS (generic + minimal) | 2026-04-23 | 2031 |
| Rocky Linux 10 | 2025-06-11 | 2035 |
| CentOS Stream 10 | 2024-12-12 | 2030 |
| openSUSE Leap 16.0 | 2025-10-01 | 2027 |

All are added as enabled images alongside the existing previous major, and the
values were populated from upstream via the update tooling (except openSUSE,
see below). CentOS keeps only a handful of builds online at a time, so the
Stream 10 pin was refreshed to a currently fetchable build (20260901.0) — the
build this branch originally recorded has since been removed upstream.

## Removed from rotation

openSUSE Leap 15.6 reached end of life on 2026-04-30 and is set to
`enable: false`. The definition is kept so operators who still need it can
re-enable it. Leap 16.0 is added first so openSUSE stays available throughout.

## Tooling

- `contrib/update.py`: register `centos-stream-10` and `rocky-10` in
  `MIRROR_DIR_CONFIG` (same BSD checksum style as their predecessors), and
  register `opensuse` with the default `MirrorDirHandler`. openSUSE was never
  wired into the updater, which is why Leap 15.6 had drifted to a 2024 build.
- `.github/workflows/update-images.yml`: add `opensuse` to the weekly update
  matrix. Registering the handler is not sufficient on its own — the workflow
  only refreshes the distributions listed there, so without this entry
  `update.py` would know how to update openSUSE but nothing would ever ask it
  to. With both changes Leap 16.0 refreshes like the other distributions.
- `contrib/mirror.py`: add `opensuse` to the shortname allow-list so Leap
  images are actually uploaded to the object store by automation.

## Testing

- `tox -- --check-only` passes (all definitions validate against
  `etc/schema.yaml`).
- `tox -e test -- test/unit` passes, including the `update.py` discovery golden
  test — the branch is rebased onto current `main`, so it now carries the
  pluggable-handler refactor.
- `tox -e update --dry-run` reports every image in this change as up-to-date
  against upstream.

## Follow-up

As usual for catalog changes, the mirror uploads run after merge: `tox -e
mirror` with object-store credentials backfills the bucket, and the new
`mirror_url` values resolve from then on.
