### PR TITLE
Verify what the mirror script uploads

### DIFF
--- a/contrib/mirror.py
+++ b/contrib/mirror.py
@@ -22,6 +22,10 @@ from urllib.parse import urlparse
 # Streaming chunk size for downloads and hashing.
 CHUNK_SIZE = 1024 * 1024
 
+# Mirrors that accept a connection and then stall must not hang the run.
+# Matches REQUESTS_TIMEOUT in openstack_image_manager/main.py.
+REQUESTS_TIMEOUT = 30
+
 app = typer.Typer(add_completion=False)
 
 
@@ -107,7 +111,10 @@ def mirror_version(
                 logger.info(f"Downloading {version['url']}")
                 try:
                     response = requests.get(
-                        version["url"], stream=True, allow_redirects=True
+                        version["url"],
+                        stream=True,
+                        allow_redirects=True,
+                        timeout=REQUESTS_TIMEOUT,
                     )
                     response.raise_for_status()
                     with open(source_filename, "wb") as fp:

--- a/contrib/mirror.py
+++ b/contrib/mirror.py
@@ -116,8 +116,30 @@ def mirror_version(
     verified = False
 
     try:
-        client.stat_object(minio_bucket, os.path.join(mirror_dirname, mirror_filename))
+        stored = client.stat_object(
+            minio_bucket, os.path.join(mirror_dirname, mirror_filename)
+        )
         logger.info(f"File {mirror_filename} available in bucket {mirror_dirname}")
+
+        mirrored_for = (stored.metadata or {}).get(UPSTREAM_CHECKSUM_HEADER)
+        expected = version.get("checksum")
+        if not mirrored_for:
+            logger.warning(
+                f"File {mirror_filename} predates checksum recording, "
+                "cannot confirm which definition it was mirrored for"
+            )
+        elif expected and mirrored_for != expected:
+            logger.error(
+                f"File {mirror_filename} in bucket {mirror_dirname} was mirrored "
+                f"for {mirrored_for}, the definition says {expected}"
+            )
+            logger.error(
+                "Leaving it untouched: either the object is wrong or the "
+                "definition changed under a fixed version. Delete the object "
+                "and run again once it is clear which."
+            )
+            return False
+
         return True
     except S3Error:
         logger.info(

--- a/contrib/mirror.py
+++ b/contrib/mirror.py
@@ -26,6 +26,11 @@ CHUNK_SIZE = 1024 * 1024
 # Matches REQUESTS_TIMEOUT in openstack_image_manager/main.py.
 REQUESTS_TIMEOUT = 30
 
+# Object metadata recording which definition an object was mirrored for.
+# minio prefixes user metadata with X-Amz-Meta- on upload.
+UPSTREAM_CHECKSUM_KEY = "upstream-checksum"
+UPSTREAM_CHECKSUM_HEADER = "x-amz-meta-upstream-checksum"
+
 app = typer.Typer(add_completion=False)
 
 
@@ -106,6 +111,10 @@ def mirror_version(
     logger.debug(f"mirror filename: {mirror_filename}")
     logger.debug(f"source filename: {source_filename}")
 
+    # Only a checksum actually verified in this run may be recorded on the
+    # object; otherwise a later run would trust bytes nobody checked.
+    verified = False
+
     try:
         client.stat_object(minio_bucket, os.path.join(mirror_dirname, mirror_filename))
         logger.info(f"File {mirror_filename} available in bucket {mirror_dirname}")
@@ -178,6 +187,7 @@ def mirror_version(
                     logger.info(
                         f"{algorithm} of {mirror_filename} matches the definition"
                     )
+                    verified = True
 
         else:
             logger.info(
@@ -187,10 +197,15 @@ def mirror_version(
         if upload:
             logger.info(f"Uploading {mirror_filename} to bucket {mirror_dirname}")
 
+            extra = {}
+            if verified:
+                extra["metadata"] = {UPSTREAM_CHECKSUM_KEY: version["checksum"]}
+
             client.fput_object(
                 minio_bucket,
                 os.path.join(mirror_dirname, mirror_filename),
                 mirror_filename,
+                **extra,
             )
 
             # Gardenlinux-specific: Upload additional files with simplified filename and SHA256 checksum

--- a/contrib/mirror.py
+++ b/contrib/mirror.py
@@ -13,6 +13,7 @@ import yaml
 from loguru import logger
 from minio import Minio
 from minio.error import S3Error
+from patoolib.util import PatoolError
 from os import listdir
 from os.path import isfile, join
 from pathlib import Path
@@ -168,16 +169,23 @@ def mirror_version(
                         os.remove(source_filename)
                     return False
 
-            if source_fileextension in [".bz2", ".zip", ".xz", ".gz"]:
-                logger.info(f"Decompressing {source_filename}")
-                Path("tmp").mkdir(exist_ok=True)
-                patoolib.extract_archive(
-                    os.path.basename(source_filename), outdir="tmp"
-                )
-                os.remove(source_filename)
-                shutil.copy(os.path.join("tmp", mirror_filename), mirror_filename)
-            else:
-                os.rename(source_filename, mirror_filename)
+            try:
+                if source_fileextension in [".bz2", ".zip", ".xz", ".gz"]:
+                    logger.info(f"Decompressing {source_filename}")
+                    Path("tmp").mkdir(exist_ok=True)
+                    patoolib.extract_archive(
+                        os.path.basename(source_filename), outdir="tmp"
+                    )
+                    os.remove(source_filename)
+                    shutil.copy(os.path.join("tmp", mirror_filename), mirror_filename)
+                else:
+                    os.rename(source_filename, mirror_filename)
+            except (PatoolError, OSError) as exc:
+                logger.error(f"Preparing {mirror_filename} for upload failed: {exc}")
+                for leftover in (source_filename, mirror_filename):
+                    if isfile(leftover):
+                        os.remove(leftover)
+                return False
 
             if checksum:
                 expected = version.get("checksum")

--- a/contrib/mirror.py
+++ b/contrib/mirror.py
@@ -29,6 +29,16 @@ REQUESTS_TIMEOUT = 30
 app = typer.Typer(add_completion=False)
 
 
+def file_checksum(path, algorithm):
+    """Return the hex digest of a file using the named hash algorithm."""
+    digest = hashlib.new(algorithm)
+    with open(path, "rb") as fp:
+        while chunk := fp.read(8192):
+            digest.update(chunk)
+
+    return digest.hexdigest()
+
+
 class MirrorPaths(NamedTuple):
     """Where one image version lives upstream and in the mirror bucket."""
 
@@ -139,12 +149,35 @@ def mirror_version(
                 os.rename(source_filename, mirror_filename)
 
             if checksum:
-                h = hashlib.new("sha512")
-                with open(mirror_filename, "rb") as fp:
-                    while c := fp.read(8192):
-                        h.update(c)
+                expected = version.get("checksum")
+                if not expected:
+                    logger.warning(
+                        f"No checksum defined for {mirror_filename}, "
+                        "it cannot be verified"
+                    )
+                else:
+                    algorithm, _, expected_digest = expected.partition(":")
+                    try:
+                        actual_digest = file_checksum(mirror_filename, algorithm)
+                    except ValueError:
+                        logger.error(
+                            f"Cannot verify {mirror_filename}: unknown checksum "
+                            f"algorithm {algorithm}"
+                        )
+                        os.remove(mirror_filename)
+                        return False
 
-                logger.info(f"SHA512 of {mirror_filename}: {h.hexdigest()}")
+                    if actual_digest != expected_digest:
+                        logger.error(
+                            f"{algorithm} of {mirror_filename} is {actual_digest}, "
+                            f"the definition says {expected_digest}"
+                        )
+                        os.remove(mirror_filename)
+                        return False
+
+                    logger.info(
+                        f"{algorithm} of {mirror_filename} matches the definition"
+                    )
 
         else:
             logger.info(
@@ -228,7 +261,9 @@ def main(
     debug: bool = typer.Option(False, "--debug", help="Enable debug logging"),
     upload: bool = typer.Option(True, "--upload/--no-upload", help="Upload images"),
     checksum: bool = typer.Option(
-        True, "--checksum/--no-checksum", help="Calculate and compare the checksum"
+        True,
+        "--checksum/--no-checksum",
+        help="Verify the download against the checksum in the definition",
     ),
     download: bool = typer.Option(
         True, "--download/--no-download", help="Download images"

--- a/contrib/mirror.py
+++ b/contrib/mirror.py
@@ -19,6 +19,9 @@ from pathlib import Path
 from typing import NamedTuple
 from urllib.parse import urlparse
 
+# Streaming chunk size for downloads and hashing.
+CHUNK_SIZE = 1024 * 1024
+
 app = typer.Typer(add_completion=False)
 
 
@@ -92,6 +95,7 @@ def mirror_version(
     try:
         client.stat_object(minio_bucket, os.path.join(mirror_dirname, mirror_filename))
         logger.info(f"File {mirror_filename} available in bucket {mirror_dirname}")
+        return True
     except S3Error:
         logger.info(
             f"File {mirror_filename} not yet available in bucket {mirror_dirname}"
@@ -101,12 +105,20 @@ def mirror_version(
             if not isfile(os.path.basename(source_filename)):
                 logger.info(f"File {source_filename} not available on local filesystem")
                 logger.info(f"Downloading {version['url']}")
-                response = requests.get(
-                    version["url"], stream=True, allow_redirects=True
-                )
-                with open(source_filename, "wb") as fp:
-                    shutil.copyfileobj(response.raw, fp)
-                del response
+                try:
+                    response = requests.get(
+                        version["url"], stream=True, allow_redirects=True
+                    )
+                    response.raise_for_status()
+                    with open(source_filename, "wb") as fp:
+                        for chunk in response.iter_content(chunk_size=CHUNK_SIZE):
+                            fp.write(chunk)
+                    del response
+                except (requests.RequestException, OSError) as exc:
+                    logger.error(f"Download of {version['url']} failed: {exc}")
+                    if isfile(source_filename):
+                        os.remove(source_filename)
+                    return False
 
             if source_fileextension in [".bz2", ".zip", ".xz", ".gz"]:
                 logger.info(f"Decompressing {source_filename}")
@@ -201,6 +213,8 @@ def mirror_version(
                 f"Not uploading {mirror_filename} to bucket {mirror_dirname} (upload disabled)"
             )
 
+    return True
+
 
 @app.command()
 def main(
@@ -268,6 +282,8 @@ def main(
                 logger.debug(f"Adding {image['name']} to the list of images")
                 all_images.append(image)
 
+    failed = []
+
     for image in all_images:
         logger.info(f"Processing image {image['name']}")
 
@@ -297,7 +313,7 @@ def main(
             if "url" not in version or "mirror_url" not in version:
                 continue
 
-            mirror_version(
+            if not mirror_version(
                 client,
                 minio_bucket,
                 image,
@@ -305,7 +321,14 @@ def main(
                 download=download,
                 checksum=checksum,
                 upload=upload,
-            )
+            ):
+                failed.append(f"{image['name']} {version['version']}")
+
+    if failed:
+        logger.error(f"Failed to mirror {len(failed)} image version(s):")
+        for entry in failed:
+            logger.error(f"  {entry}")
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/contrib/mirror.py
+++ b/contrib/mirror.py
@@ -16,9 +16,190 @@ from minio.error import S3Error
 from os import listdir
 from os.path import isfile, join
 from pathlib import Path
+from typing import NamedTuple
 from urllib.parse import urlparse
 
 app = typer.Typer(add_completion=False)
+
+
+class MirrorPaths(NamedTuple):
+    """Where one image version lives upstream and in the mirror bucket."""
+
+    dirname: str
+    filename: str
+    source_filename: str
+    source_extension: str
+
+
+def mirror_paths(image, version):
+    """Derive the bucket path and local download name for one version."""
+    source_path = urlparse(version["url"])
+    mirror_path = urlparse(version["mirror_url"])
+
+    mirror_dirname = f"openstack-images/{image['shortname']}"
+    mirror_filename, mirror_fileextension = os.path.splitext(
+        os.path.basename(mirror_path.path)
+    )
+    _, mirror_fileextension2 = os.path.splitext(mirror_filename)
+
+    if not image["shortname"].startswith(
+        ("gardenlinux", "talos", "flatcar", "opnsense")
+    ):
+        mirror_filename = f"{version['version']}-{image['shortname']}"
+
+    if mirror_fileextension not in [".bz2", ".zip", ".xz", ".gz"]:
+        mirror_filename += mirror_fileextension
+
+    if mirror_fileextension2 == ".tar":
+        mirror_filename = os.path.basename(mirror_path.path)
+
+    source_filename, source_fileextension = os.path.splitext(
+        os.path.basename(source_path.path)
+    )
+    _, source_fileextension2 = os.path.splitext(source_filename)
+
+    if image["shortname"].startswith(("flatcar")):
+        mirror_dirname = os.path.join(mirror_dirname, version["version"])
+    elif source_fileextension not in [".bz2", ".zip", ".xz", ".gz"]:
+        source_filename += source_fileextension
+    else:
+        mirror_dirname = os.path.join(mirror_dirname, version["version"])
+
+    if source_fileextension2 == ".tar":
+        source_filename = os.path.basename(source_path.path)
+
+    return MirrorPaths(
+        mirror_dirname, mirror_filename, source_filename, source_fileextension
+    )
+
+
+def mirror_version(
+    client, minio_bucket, image, version, download=True, checksum=True, upload=True
+):
+    """Mirror one image version into the bucket unless it is already there."""
+    logger.debug(f"source: {version['url']}")
+
+    paths = mirror_paths(image, version)
+    mirror_dirname = paths.dirname
+    mirror_filename = paths.filename
+    source_filename = paths.source_filename
+    source_fileextension = paths.source_extension
+
+    logger.debug(f"mirror dirname: {mirror_dirname}")
+    logger.debug(f"mirror filename: {mirror_filename}")
+    logger.debug(f"source filename: {source_filename}")
+
+    try:
+        client.stat_object(minio_bucket, os.path.join(mirror_dirname, mirror_filename))
+        logger.info(f"File {mirror_filename} available in bucket {mirror_dirname}")
+    except S3Error:
+        logger.info(
+            f"File {mirror_filename} not yet available in bucket {mirror_dirname}"
+        )
+
+        if download:
+            if not isfile(os.path.basename(source_filename)):
+                logger.info(f"File {source_filename} not available on local filesystem")
+                logger.info(f"Downloading {version['url']}")
+                response = requests.get(
+                    version["url"], stream=True, allow_redirects=True
+                )
+                with open(source_filename, "wb") as fp:
+                    shutil.copyfileobj(response.raw, fp)
+                del response
+
+            if source_fileextension in [".bz2", ".zip", ".xz", ".gz"]:
+                logger.info(f"Decompressing {source_filename}")
+                Path("tmp").mkdir(exist_ok=True)
+                patoolib.extract_archive(
+                    os.path.basename(source_filename), outdir="tmp"
+                )
+                os.remove(source_filename)
+                shutil.copy(os.path.join("tmp", mirror_filename), mirror_filename)
+            else:
+                os.rename(source_filename, mirror_filename)
+
+            if checksum:
+                h = hashlib.new("sha512")
+                with open(mirror_filename, "rb") as fp:
+                    while c := fp.read(8192):
+                        h.update(c)
+
+                logger.info(f"SHA512 of {mirror_filename}: {h.hexdigest()}")
+
+        else:
+            logger.info(
+                f"Not downloading {source_filename} to local filesystem (download disabled)"
+            )
+
+        if upload:
+            logger.info(f"Uploading {mirror_filename} to bucket {mirror_dirname}")
+
+            client.fput_object(
+                minio_bucket,
+                os.path.join(mirror_dirname, mirror_filename),
+                mirror_filename,
+            )
+
+            # Gardenlinux-specific: Upload additional files with simplified filename and SHA256 checksum
+            if image["shortname"] == "gardenlinux":
+                # Check if filename matches pattern with hash suffix: *-[8-char-hex].qcow2
+                hash_pattern = re.compile(r"-([a-f0-9]{8})\.qcow2$")
+                match = hash_pattern.search(mirror_filename)
+
+                if match:
+                    # Create simplified filename by removing hash suffix
+                    simplified_filename = hash_pattern.sub(".qcow2", mirror_filename)
+                    logger.info(f"Creating simplified filename: {simplified_filename}")
+
+                    # Create symlink to simplified filename
+                    if os.path.exists(simplified_filename):
+                        os.remove(simplified_filename)
+                    os.symlink(mirror_filename, simplified_filename)
+
+                    # Upload simplified filename
+                    logger.info(
+                        f"Uploading {simplified_filename} to bucket {mirror_dirname}"
+                    )
+                    client.fput_object(
+                        minio_bucket,
+                        os.path.join(mirror_dirname, simplified_filename),
+                        simplified_filename,
+                    )
+
+                    # Calculate SHA256 checksum
+                    h_sha256 = hashlib.sha256()
+                    with open(mirror_filename, "rb") as fp:
+                        while chunk := fp.read(8192):
+                            h_sha256.update(chunk)
+
+                    sha256_hash = h_sha256.hexdigest()
+                    logger.info(f"SHA256 of {simplified_filename}: {sha256_hash}")
+
+                    # Create SHA256 checksum file
+                    sha256_filename = f"{simplified_filename}.sha256"
+                    with open(sha256_filename, "w") as fp:
+                        fp.write(f"{sha256_hash}  {simplified_filename}\n")
+
+                    # Upload SHA256 checksum file
+                    logger.info(
+                        f"Uploading {sha256_filename} to bucket {mirror_dirname}"
+                    )
+                    client.fput_object(
+                        minio_bucket,
+                        os.path.join(mirror_dirname, sha256_filename),
+                        sha256_filename,
+                    )
+
+                    # Clean up temporary files
+                    os.remove(simplified_filename)
+                    os.remove(sha256_filename)
+
+            os.remove(mirror_filename)
+        else:
+            logger.info(
+                f"Not uploading {mirror_filename} to bucket {mirror_dirname} (upload disabled)"
+            )
 
 
 @app.command()
@@ -116,175 +297,15 @@ def main(
             if "url" not in version or "mirror_url" not in version:
                 continue
 
-            logger.debug(f"source: {version['url']}")
-
-            source_path = urlparse(version["url"])
-            mirror_path = urlparse(version["mirror_url"])
-
-            mirror_dirname = f"openstack-images/{image['shortname']}"
-            mirror_filename, mirror_fileextension = os.path.splitext(
-                os.path.basename(mirror_path.path)
+            mirror_version(
+                client,
+                minio_bucket,
+                image,
+                version,
+                download=download,
+                checksum=checksum,
+                upload=upload,
             )
-            _, mirror_fileextension2 = os.path.splitext(mirror_filename)
-
-            if not image["shortname"].startswith(
-                ("gardenlinux", "talos", "flatcar", "opnsense")
-            ):
-                mirror_filename = f"{version['version']}-{image['shortname']}"
-
-            if mirror_fileextension not in [".bz2", ".zip", ".xz", ".gz"]:
-                mirror_filename += mirror_fileextension
-
-            if mirror_fileextension2 == ".tar":
-                mirror_filename = os.path.basename(mirror_path.path)
-
-            logger.debug(f"mirror dirname: {mirror_dirname}")
-            logger.debug(f"mirror filename: {mirror_filename}")
-
-            source_filename, source_fileextension = os.path.splitext(
-                os.path.basename(source_path.path)
-            )
-            _, source_fileextension2 = os.path.splitext(source_filename)
-
-            if image["shortname"].startswith(("flatcar")):
-                mirror_dirname = os.path.join(mirror_dirname, version["version"])
-            elif source_fileextension not in [".bz2", ".zip", ".xz", ".gz"]:
-                source_filename += source_fileextension
-            else:
-                mirror_dirname = os.path.join(mirror_dirname, version["version"])
-
-            if source_fileextension2 == ".tar":
-                source_filename = os.path.basename(source_path.path)
-
-            logger.debug(f"source filename: {source_filename}")
-
-            try:
-                client.stat_object(
-                    minio_bucket, os.path.join(mirror_dirname, mirror_filename)
-                )
-                logger.info(
-                    f"File {mirror_filename} available in bucket {mirror_dirname}"
-                )
-            except S3Error:
-                logger.info(
-                    f"File {mirror_filename} not yet available in bucket {mirror_dirname}"
-                )
-
-                if download:
-                    if not isfile(os.path.basename(source_filename)):
-                        logger.info(
-                            f"File {source_filename} not available on local filesystem"
-                        )
-                        logger.info(f"Downloading {version['url']}")
-                        response = requests.get(
-                            version["url"], stream=True, allow_redirects=True
-                        )
-                        with open(source_filename, "wb") as fp:
-                            shutil.copyfileobj(response.raw, fp)
-                        del response
-
-                    if source_fileextension in [".bz2", ".zip", ".xz", ".gz"]:
-                        logger.info(f"Decompressing {source_filename}")
-                        Path("tmp").mkdir(exist_ok=True)
-                        patoolib.extract_archive(
-                            os.path.basename(source_filename), outdir="tmp"
-                        )
-                        os.remove(source_filename)
-                        shutil.copy(
-                            os.path.join("tmp", mirror_filename), mirror_filename
-                        )
-                    else:
-                        os.rename(source_filename, mirror_filename)
-
-                    if checksum:
-                        h = hashlib.new("sha512")
-                        with open(mirror_filename, "rb") as fp:
-                            while c := fp.read(8192):
-                                h.update(c)
-
-                        logger.info(f"SHA512 of {mirror_filename}: {h.hexdigest()}")
-
-                else:
-                    logger.info(
-                        f"Not downloading {source_filename} to local filesystem (download disabled)"
-                    )
-
-                if upload:
-                    logger.info(
-                        f"Uploading {mirror_filename} to bucket {mirror_dirname}"
-                    )
-
-                    client.fput_object(
-                        minio_bucket,
-                        os.path.join(mirror_dirname, mirror_filename),
-                        mirror_filename,
-                    )
-
-                    # Gardenlinux-specific: Upload additional files with simplified filename and SHA256 checksum
-                    if image["shortname"] == "gardenlinux":
-                        # Check if filename matches pattern with hash suffix: *-[8-char-hex].qcow2
-                        hash_pattern = re.compile(r"-([a-f0-9]{8})\.qcow2$")
-                        match = hash_pattern.search(mirror_filename)
-
-                        if match:
-                            # Create simplified filename by removing hash suffix
-                            simplified_filename = hash_pattern.sub(
-                                ".qcow2", mirror_filename
-                            )
-                            logger.info(
-                                f"Creating simplified filename: {simplified_filename}"
-                            )
-
-                            # Create symlink to simplified filename
-                            if os.path.exists(simplified_filename):
-                                os.remove(simplified_filename)
-                            os.symlink(mirror_filename, simplified_filename)
-
-                            # Upload simplified filename
-                            logger.info(
-                                f"Uploading {simplified_filename} to bucket {mirror_dirname}"
-                            )
-                            client.fput_object(
-                                minio_bucket,
-                                os.path.join(mirror_dirname, simplified_filename),
-                                simplified_filename,
-                            )
-
-                            # Calculate SHA256 checksum
-                            h_sha256 = hashlib.sha256()
-                            with open(mirror_filename, "rb") as fp:
-                                while chunk := fp.read(8192):
-                                    h_sha256.update(chunk)
-
-                            sha256_hash = h_sha256.hexdigest()
-                            logger.info(
-                                f"SHA256 of {simplified_filename}: {sha256_hash}"
-                            )
-
-                            # Create SHA256 checksum file
-                            sha256_filename = f"{simplified_filename}.sha256"
-                            with open(sha256_filename, "w") as fp:
-                                fp.write(f"{sha256_hash}  {simplified_filename}\n")
-
-                            # Upload SHA256 checksum file
-                            logger.info(
-                                f"Uploading {sha256_filename} to bucket {mirror_dirname}"
-                            )
-                            client.fput_object(
-                                minio_bucket,
-                                os.path.join(mirror_dirname, sha256_filename),
-                                sha256_filename,
-                            )
-
-                            # Clean up temporary files
-                            os.remove(simplified_filename)
-                            os.remove(sha256_filename)
-
-                    os.remove(mirror_filename)
-                else:
-                    logger.info(
-                        f"Not uploading {mirror_filename} to bucket {mirror_dirname} (upload disabled)"
-                    )
 
 
 if __name__ == "__main__":

--- a/test/unit/test_mirror.py
+++ b/test/unit/test_mirror.py
@@ -176,6 +176,16 @@ class MirrorVersionTest(unittest.TestCase):
             ["openstack-images/ubuntu-24.04/20260108-ubuntu-24.04.qcow2"],
         )
 
+    def test_download_uses_a_request_timeout(self):
+        # A mirror that accepts the connection and then stalls must not hang
+        # the run forever; requests only enforces that if asked to.
+        client = _FakeClient()
+
+        with mock.patch.object(mirror.requests, "get", return_value=_response()) as get:
+            mirror.mirror_version(client, BUCKET, UBUNTU, UBUNTU["versions"][0])
+
+        self.assertEqual(get.call_args.kwargs["timeout"], mirror.REQUESTS_TIMEOUT)
+
 
 class DownloadFailureTest(unittest.TestCase):
     def setUp(self):

--- a/test/unit/test_mirror.py
+++ b/test/unit/test_mirror.py
@@ -443,6 +443,45 @@ class ObjectMetadataTest(unittest.TestCase):
             stored.metadata.get("x-amz-meta-upstream-checksum"), version["checksum"]
         )
 
+    def test_object_matching_the_definition_is_left_alone(self):
+        client = _FakeClient()
+        version = UBUNTU["versions"][0]
+        self._mirror(client, version)
+
+        ok = self._mirror(client, version)
+
+        self.assertIs(ok, True)
+        self.assertEqual(len(client.uploaded), 1)
+
+    def test_object_mirrored_for_another_checksum_fails(self):
+        client = _FakeClient()
+        self._mirror(client, UBUNTU["versions"][0])
+
+        changed = _version_with_checksum(UBUNTU, "sha256:" + "0" * 64)
+        ok = self._mirror(client, changed)
+
+        self.assertIs(ok, False)
+
+    def test_mismatching_object_is_not_overwritten(self):
+        client = _FakeClient()
+        self._mirror(client, UBUNTU["versions"][0])
+
+        changed = _version_with_checksum(UBUNTU, "sha256:" + "0" * 64)
+        self._mirror(client, changed)
+
+        self.assertEqual(len(client.uploaded), 1)
+
+    def test_object_without_metadata_is_skipped_without_failing(self):
+        # Everything mirrored before this change has no recorded checksum.
+        client = _FakeClient(
+            existing={"openstack-images/ubuntu-24.04/20260108-ubuntu-24.04.qcow2"}
+        )
+
+        ok = self._mirror(client, UBUNTU["versions"][0])
+
+        self.assertIs(ok, True)
+        self.assertEqual(client.uploaded, [])
+
 
 SAMPLE_YML = """\
 ---

--- a/test/unit/test_mirror.py
+++ b/test/unit/test_mirror.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import hashlib
 import io
 import os
 import shutil
@@ -13,8 +14,12 @@ from urllib3.exceptions import ProtocolError
 
 import contrib.mirror as mirror
 
+PAYLOAD = b"image-bytes"
+PAYLOAD_SHA256 = hashlib.sha256(PAYLOAD).hexdigest()
+
 # Fixtures follow the shape of real etc/images entries, one per naming branch
 # mirror_paths has to handle.
+# Their checksums are the digest of the payload the fake download serves.
 
 UBUNTU = {
     "shortname": "ubuntu-24.04",
@@ -26,7 +31,7 @@ UBUNTU = {
                 "https://nbg1.your-objectstorage.com/osism/openstack-images/"
                 "ubuntu-24.04/20260108-ubuntu-24.04.qcow2"
             ),
-            "checksum": "sha256:" + "a" * 64,
+            "checksum": f"sha256:{PAYLOAD_SHA256}",
         }
     ],
 }
@@ -41,7 +46,7 @@ TALOS = {
                 "https://nbg1.your-objectstorage.com/osism/openstack-images/"
                 "talos/1.11.3/openstack-amd64"
             ),
-            "checksum": "sha256:" + "b" * 64,
+            "checksum": f"sha256:{PAYLOAD_SHA256}",
         }
     ],
 }
@@ -59,7 +64,7 @@ GARDENLINUX = {
                 "https://nbg1.your-objectstorage.com/osism/openstack-images/"
                 "gardenlinux/1592.14/openstack-gardener_prod-amd64-1592.14-730f446c.qcow2"
             ),
-            "checksum": "sha256:" + "c" * 64,
+            "checksum": f"sha256:{PAYLOAD_SHA256}",
         }
     ],
 }
@@ -107,7 +112,7 @@ class _BrokenStream:
         raise ProtocolError("connection broken: incomplete read")
 
 
-def _response(payload=b"image-bytes", status=200):
+def _response(payload=PAYLOAD, status=200):
     """A real requests.Response, so raise_for_status() behaves as in production."""
     response = requests.Response()
     response.status_code = status
@@ -264,6 +269,118 @@ class DownloadFailureTest(unittest.TestCase):
             ok = mirror.mirror_version(client, BUCKET, UBUNTU, UBUNTU["versions"][0])
 
         self.assertIs(ok, True)
+
+
+def _version_with_checksum(image, checksum):
+    version = dict(image["versions"][0])
+    version["checksum"] = checksum
+    return version
+
+
+class ChecksumTest(unittest.TestCase):
+    def setUp(self):
+        self.dir = tempfile.mkdtemp()
+        self.cwd = os.getcwd()
+        os.chdir(self.dir)
+        self.payload = PAYLOAD
+
+    def tearDown(self):
+        os.chdir(self.cwd)
+        shutil.rmtree(self.dir)
+
+    def _mirror(self, version):
+        client = _FakeClient()
+        with mock.patch.object(
+            mirror.requests, "get", return_value=_response(self.payload)
+        ):
+            ok = mirror.mirror_version(client, BUCKET, UBUNTU, version)
+        return ok, client
+
+    def test_mismatching_checksum_is_not_uploaded(self):
+        version = _version_with_checksum(UBUNTU, "sha256:" + "0" * 64)
+
+        ok, client = self._mirror(version)
+
+        self.assertIs(ok, False)
+        self.assertEqual(client.uploaded, [])
+
+    def test_matching_checksum_is_uploaded(self):
+        digest = hashlib.sha256(self.payload).hexdigest()
+        version = _version_with_checksum(UBUNTU, f"sha256:{digest}")
+
+        ok, client = self._mirror(version)
+
+        self.assertIs(ok, True)
+        self.assertEqual(len(client.uploaded), 1)
+
+    def test_algorithm_comes_from_the_definition(self):
+        # Two catalog entries use sha512, so the algorithm cannot be hardcoded.
+        digest = hashlib.sha512(self.payload).hexdigest()
+        version = _version_with_checksum(UBUNTU, f"sha512:{digest}")
+
+        ok, _ = self._mirror(version)
+
+        self.assertIs(ok, True)
+
+    def test_mismatch_leaves_no_local_file_behind(self):
+        # upload=False, so nothing else can clean up after the rejected file.
+        version = _version_with_checksum(UBUNTU, "sha256:" + "0" * 64)
+        client = _FakeClient()
+
+        with mock.patch.object(
+            mirror.requests, "get", return_value=_response(self.payload)
+        ):
+            mirror.mirror_version(client, BUCKET, UBUNTU, version, upload=False)
+
+        self.assertEqual(os.listdir("."), [])
+
+    def _extracting(self, produced):
+        """Stand in for patoolib, producing the bytes the archive unpacks to."""
+
+        def extract(name, outdir):
+            os.makedirs(outdir, exist_ok=True)
+            target = mirror.mirror_paths(TALOS, TALOS["versions"][0]).filename
+            with open(os.path.join(outdir, target), "wb") as fp:
+                fp.write(produced)
+
+        return extract
+
+    def test_compressed_source_is_checked_after_decompression(self):
+        # For a compressed source the mirror stores the unpacked image, and the
+        # definition's checksum describes that -- contrib/update-gardenlinux.py
+        # hashes the extracted qcow2, and main.py downloads mirror_url. So the
+        # archive's own bytes are not what has to match.
+        unpacked = b"unpacked-image-bytes"
+        version = _version_with_checksum(
+            TALOS, f"sha256:{hashlib.sha256(unpacked).hexdigest()}"
+        )
+        client = _FakeClient()
+
+        with mock.patch.object(
+            mirror.requests, "get", return_value=_response(b"archive-bytes")
+        ):
+            with mock.patch.object(
+                mirror.patoolib, "extract_archive", self._extracting(unpacked)
+            ):
+                ok = mirror.mirror_version(client, BUCKET, TALOS, version)
+
+        self.assertIs(ok, True)
+        self.assertEqual(len(client.uploaded), 1)
+
+    def test_unpacked_image_that_does_not_match_is_not_uploaded(self):
+        version = _version_with_checksum(TALOS, "sha256:" + "0" * 64)
+        client = _FakeClient()
+
+        with mock.patch.object(
+            mirror.requests, "get", return_value=_response(b"archive-bytes")
+        ):
+            with mock.patch.object(
+                mirror.patoolib, "extract_archive", self._extracting(b"wrong-image")
+            ):
+                ok = mirror.mirror_version(client, BUCKET, TALOS, version)
+
+        self.assertIs(ok, False)
+        self.assertEqual(client.uploaded, [])
 
 
 SAMPLE_YML = """\

--- a/test/unit/test_mirror.py
+++ b/test/unit/test_mirror.py
@@ -1,0 +1,157 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import io
+import os
+import shutil
+import tempfile
+import unittest
+from unittest import mock
+
+from minio.error import S3Error
+
+import contrib.mirror as mirror
+
+# Fixtures follow the shape of real etc/images entries, one per naming branch
+# mirror_paths has to handle.
+
+UBUNTU = {
+    "shortname": "ubuntu-24.04",
+    "versions": [
+        {
+            "version": "20260108",
+            "url": "https://cloud-images.ubuntu.com/noble/20260108/noble-server-cloudimg-amd64.img",
+            "mirror_url": (
+                "https://nbg1.your-objectstorage.com/osism/openstack-images/"
+                "ubuntu-24.04/20260108-ubuntu-24.04.qcow2"
+            ),
+            "checksum": "sha256:" + "a" * 64,
+        }
+    ],
+}
+
+TALOS = {
+    "shortname": "talos",
+    "versions": [
+        {
+            "version": "1.11.3",
+            "url": "https://factory.talos.dev/image/376567988ad37013/v1.11.3/openstack-amd64.raw.xz",
+            "mirror_url": (
+                "https://nbg1.your-objectstorage.com/osism/openstack-images/"
+                "talos/1.11.3/openstack-amd64"
+            ),
+            "checksum": "sha256:" + "b" * 64,
+        }
+    ],
+}
+
+GARDENLINUX = {
+    "shortname": "gardenlinux",
+    "versions": [
+        {
+            "version": "1592.14",
+            "url": (
+                "https://github.com/gardenlinux/gardenlinux/releases/download/1592.14/"
+                "openstack-gardener_prod-amd64-1592.14-730f446c.tar.xz"
+            ),
+            "mirror_url": (
+                "https://nbg1.your-objectstorage.com/osism/openstack-images/"
+                "gardenlinux/1592.14/openstack-gardener_prod-amd64-1592.14-730f446c.qcow2"
+            ),
+            "checksum": "sha256:" + "c" * 64,
+        }
+    ],
+}
+
+BUCKET = "osism"
+
+
+def _missing_object():
+    return S3Error(None, "NoSuchKey", "not found", "object", "request", "host")
+
+
+class _FakeClient:
+    """Minimal stand-in for minio.Minio that records what the mirror step does."""
+
+    def __init__(self, existing=()):
+        self.existing = set(existing)
+        self.statted = []
+        self.uploaded = []
+
+    def stat_object(self, bucket, name):
+        self.statted.append(name)
+        if name not in self.existing:
+            raise _missing_object()
+        return mock.Mock(metadata={})
+
+    def fput_object(self, bucket, name, path, **kwargs):
+        self.uploaded.append((name, path, kwargs))
+
+
+def _response(payload=b"image-bytes"):
+    return mock.Mock(raw=io.BytesIO(payload))
+
+
+class MirrorPathsTest(unittest.TestCase):
+    def test_plain_image_keeps_a_flat_directory(self):
+        paths = mirror.mirror_paths(UBUNTU, UBUNTU["versions"][0])
+
+        self.assertEqual(paths.dirname, "openstack-images/ubuntu-24.04")
+        self.assertEqual(paths.filename, "20260108-ubuntu-24.04.qcow2")
+        self.assertEqual(paths.source_filename, "noble-server-cloudimg-amd64.img")
+
+    def test_compressed_source_gets_a_versioned_directory(self):
+        paths = mirror.mirror_paths(TALOS, TALOS["versions"][0])
+
+        self.assertEqual(paths.dirname, "openstack-images/talos/1.11.3")
+        self.assertEqual(paths.filename, "openstack-amd64")
+        self.assertEqual(paths.source_filename, "openstack-amd64.raw")
+
+    def test_tar_source_keeps_its_full_filename(self):
+        paths = mirror.mirror_paths(GARDENLINUX, GARDENLINUX["versions"][0])
+
+        self.assertEqual(paths.dirname, "openstack-images/gardenlinux/1592.14")
+        self.assertEqual(
+            paths.filename, "openstack-gardener_prod-amd64-1592.14-730f446c.qcow2"
+        )
+        self.assertEqual(
+            paths.source_filename,
+            "openstack-gardener_prod-amd64-1592.14-730f446c.tar.xz",
+        )
+
+
+class MirrorVersionTest(unittest.TestCase):
+    def setUp(self):
+        self.dir = tempfile.mkdtemp()
+        self.cwd = os.getcwd()
+        os.chdir(self.dir)
+
+    def tearDown(self):
+        os.chdir(self.cwd)
+        shutil.rmtree(self.dir)
+
+    def test_object_already_in_the_bucket_is_not_downloaded(self):
+        client = _FakeClient(
+            existing={"openstack-images/ubuntu-24.04/20260108-ubuntu-24.04.qcow2"}
+        )
+
+        with mock.patch.object(mirror.requests, "get") as get:
+            mirror.mirror_version(client, BUCKET, UBUNTU, UBUNTU["versions"][0])
+
+        get.assert_not_called()
+        self.assertEqual(client.uploaded, [])
+
+    def test_missing_object_is_downloaded_and_uploaded(self):
+        client = _FakeClient()
+
+        with mock.patch.object(mirror.requests, "get", return_value=_response()) as get:
+            mirror.mirror_version(client, BUCKET, UBUNTU, UBUNTU["versions"][0])
+
+        get.assert_called_once()
+        self.assertEqual(
+            [name for name, _, _ in client.uploaded],
+            ["openstack-images/ubuntu-24.04/20260108-ubuntu-24.04.qcow2"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unit/test_mirror.py
+++ b/test/unit/test_mirror.py
@@ -7,7 +7,9 @@ import tempfile
 import unittest
 from unittest import mock
 
+import requests
 from minio.error import S3Error
+from urllib3.exceptions import ProtocolError
 
 import contrib.mirror as mirror
 
@@ -77,6 +79,9 @@ class _FakeClient:
         self.statted = []
         self.uploaded = []
 
+    def bucket_exists(self, bucket):
+        return True
+
     def stat_object(self, bucket, name):
         self.statted.append(name)
         if name not in self.existing:
@@ -87,8 +92,27 @@ class _FakeClient:
         self.uploaded.append((name, path, kwargs))
 
 
-def _response(payload=b"image-bytes"):
-    return mock.Mock(raw=io.BytesIO(payload))
+class _BrokenStream:
+    """Stands in for a urllib3 response whose transfer dies partway through.
+
+    Real urllib3 responses expose stream(); requests uses it when present and
+    translates urllib3 errors raised from it, so the fake has to have it too.
+    """
+
+    def stream(self, chunk_size, decode_content=True):
+        yield b"partial-"
+        raise ProtocolError("connection broken: incomplete read")
+
+    def read(self, size=-1):
+        raise ProtocolError("connection broken: incomplete read")
+
+
+def _response(payload=b"image-bytes", status=200):
+    """A real requests.Response, so raise_for_status() behaves as in production."""
+    response = requests.Response()
+    response.status_code = status
+    response.raw = io.BytesIO(payload)
+    return response
 
 
 class MirrorPathsTest(unittest.TestCase):
@@ -151,6 +175,142 @@ class MirrorVersionTest(unittest.TestCase):
             [name for name, _, _ in client.uploaded],
             ["openstack-images/ubuntu-24.04/20260108-ubuntu-24.04.qcow2"],
         )
+
+
+class DownloadFailureTest(unittest.TestCase):
+    def setUp(self):
+        self.dir = tempfile.mkdtemp()
+        self.cwd = os.getcwd()
+        os.chdir(self.dir)
+
+    def tearDown(self):
+        os.chdir(self.cwd)
+        shutil.rmtree(self.dir)
+
+    def test_error_response_is_never_uploaded(self):
+        client = _FakeClient()
+
+        with mock.patch.object(
+            mirror.requests, "get", return_value=_response(b"<html>502</html>", 502)
+        ):
+            ok = mirror.mirror_version(client, BUCKET, UBUNTU, UBUNTU["versions"][0])
+
+        self.assertIs(ok, False)
+        self.assertEqual(client.uploaded, [])
+
+    def test_error_response_leaves_no_local_file_behind(self):
+        # upload=False, so nothing else can clean up after the failed download.
+        client = _FakeClient()
+
+        with mock.patch.object(
+            mirror.requests, "get", return_value=_response(b"<html>404</html>", 404)
+        ):
+            mirror.mirror_version(
+                client, BUCKET, UBUNTU, UBUNTU["versions"][0], upload=False
+            )
+
+        self.assertEqual(os.listdir("."), [])
+
+    def test_connection_failure_is_reported_not_raised(self):
+        client = _FakeClient()
+
+        with mock.patch.object(
+            mirror.requests, "get", side_effect=requests.ConnectionError("no route")
+        ):
+            ok = mirror.mirror_version(client, BUCKET, UBUNTU, UBUNTU["versions"][0])
+
+        self.assertIs(ok, False)
+        self.assertEqual(client.uploaded, [])
+
+    def test_failure_midway_through_the_stream_is_reported_not_raised(self):
+        # Reading response.raw goes straight to urllib3, so a mid-stream
+        # failure is a urllib3 error, not a requests one.
+        client = _FakeClient()
+        broken = _response()
+        broken.raw = _BrokenStream()
+
+        with mock.patch.object(mirror.requests, "get", return_value=broken):
+            ok = mirror.mirror_version(client, BUCKET, UBUNTU, UBUNTU["versions"][0])
+
+        self.assertIs(ok, False)
+        self.assertEqual(client.uploaded, [])
+
+    def test_failed_stream_leaves_no_partial_file(self):
+        client = _FakeClient()
+        broken = _response()
+        broken.raw = _BrokenStream()
+
+        with mock.patch.object(mirror.requests, "get", return_value=broken):
+            mirror.mirror_version(
+                client, BUCKET, UBUNTU, UBUNTU["versions"][0], upload=False
+            )
+
+        self.assertEqual(os.listdir("."), [])
+
+    def test_successful_mirror_reports_success(self):
+        client = _FakeClient()
+
+        with mock.patch.object(mirror.requests, "get", return_value=_response()):
+            ok = mirror.mirror_version(client, BUCKET, UBUNTU, UBUNTU["versions"][0])
+
+        self.assertIs(ok, True)
+
+
+SAMPLE_YML = """\
+---
+images:
+  - name: Ubuntu 24.04
+    shortname: ubuntu-24.04
+    versions:
+      - version: '20260108'
+        url: https://cloud-images.ubuntu.com/noble/20260108/noble-server-cloudimg-amd64.img
+        mirror_url: https://nbg1.your-objectstorage.com/osism/openstack-images/ubuntu-24.04/20260108-ubuntu-24.04.qcow2
+        checksum: sha256:0000000000000000000000000000000000000000000000000000000000000000
+"""
+
+
+class ExitStatusTest(unittest.TestCase):
+    def setUp(self):
+        self.dir = tempfile.mkdtemp()
+        self.images = os.path.join(self.dir, "images")
+        os.mkdir(self.images)
+        with open(os.path.join(self.images, "ubuntu.yml"), "w") as fp:
+            fp.write(SAMPLE_YML)
+        self.cwd = os.getcwd()
+        os.chdir(self.dir)
+
+    def tearDown(self):
+        os.chdir(self.cwd)
+        shutil.rmtree(self.dir)
+
+    def _run(self, response):
+        client = _FakeClient()
+        with mock.patch.object(mirror, "Minio", return_value=client):
+            with mock.patch.object(mirror.requests, "get", return_value=response):
+                mirror.main(
+                    debug=False,
+                    upload=True,
+                    checksum=False,
+                    download=True,
+                    delete=True,
+                    images=self.images,
+                    minio_access_key="key",
+                    minio_secret_key="secret",
+                    minio_server="object.test",
+                    minio_bucket=BUCKET,
+                )
+        return client
+
+    def test_failed_version_exits_non_zero(self):
+        with self.assertRaises(SystemExit) as caught:
+            self._run(_response(b"<html>502</html>", 502))
+
+        self.assertEqual(caught.exception.code, 1)
+
+    def test_run_without_failures_does_not_exit(self):
+        client = self._run(_response())
+
+        self.assertEqual(len(client.uploaded), 1)
 
 
 if __name__ == "__main__":

--- a/test/unit/test_mirror.py
+++ b/test/unit/test_mirror.py
@@ -10,6 +10,7 @@ from unittest import mock
 
 import requests
 from minio.error import S3Error
+from urllib3 import HTTPHeaderDict
 from urllib3.exceptions import ProtocolError
 
 import contrib.mirror as mirror
@@ -77,10 +78,15 @@ def _missing_object():
 
 
 class _FakeClient:
-    """Minimal stand-in for minio.Minio that records what the mirror step does."""
+    """Minimal stand-in for minio.Minio that records what the mirror step does.
+
+    Metadata is stored the way minio stores it: user keys are prefixed with
+    X-Amz-Meta- on the way in and read back out of a case-insensitive header
+    mapping, so production code has to look them up as minio presents them.
+    """
 
     def __init__(self, existing=()):
-        self.existing = set(existing)
+        self.existing = {name: HTTPHeaderDict() for name in existing}
         self.statted = []
         self.uploaded = []
 
@@ -91,10 +97,14 @@ class _FakeClient:
         self.statted.append(name)
         if name not in self.existing:
             raise _missing_object()
-        return mock.Mock(metadata={})
+        return mock.Mock(metadata=self.existing[name])
 
     def fput_object(self, bucket, name, path, **kwargs):
         self.uploaded.append((name, path, kwargs))
+        headers = HTTPHeaderDict()
+        for key, value in (kwargs.get("metadata") or {}).items():
+            headers[f"X-Amz-Meta-{key}"] = value
+        self.existing[name] = headers
 
 
 class _BrokenStream:
@@ -381,6 +391,57 @@ class ChecksumTest(unittest.TestCase):
 
         self.assertIs(ok, False)
         self.assertEqual(client.uploaded, [])
+
+
+class ObjectMetadataTest(unittest.TestCase):
+    def setUp(self):
+        self.dir = tempfile.mkdtemp()
+        self.cwd = os.getcwd()
+        os.chdir(self.dir)
+
+    def tearDown(self):
+        os.chdir(self.cwd)
+        shutil.rmtree(self.dir)
+
+    def _mirror(self, client, version):
+        with mock.patch.object(mirror.requests, "get", return_value=_response()):
+            return mirror.mirror_version(client, BUCKET, UBUNTU, version)
+
+    def test_version_without_a_checksum_records_no_provenance(self):
+        # The schema allows a version with no checksum; there is then nothing
+        # meaningful to record, and an empty value would read back as garbage.
+        client = _FakeClient()
+        version = dict(UBUNTU["versions"][0])
+        del version["checksum"]
+
+        ok = self._mirror(client, version)
+
+        self.assertIs(ok, True)
+        self.assertNotIn("metadata", client.uploaded[0][2])
+
+    def test_unverified_download_records_no_provenance(self):
+        # With --no-checksum the bytes were never checked, so stamping them as
+        # matching the definition would make a later run trust them.
+        client = _FakeClient()
+
+        with mock.patch.object(mirror.requests, "get", return_value=_response()):
+            ok = mirror.mirror_version(
+                client, BUCKET, UBUNTU, UBUNTU["versions"][0], checksum=False
+            )
+
+        self.assertIs(ok, True)
+        self.assertNotIn("metadata", client.uploaded[0][2])
+
+    def test_upload_records_which_checksum_it_was_mirrored_for(self):
+        client = _FakeClient()
+        version = UBUNTU["versions"][0]
+
+        self._mirror(client, version)
+
+        stored = client.stat_object(BUCKET, client.uploaded[0][0])
+        self.assertEqual(
+            stored.metadata.get("x-amz-meta-upstream-checksum"), version["checksum"]
+        )
 
 
 SAMPLE_YML = """\

--- a/test/unit/test_mirror.py
+++ b/test/unit/test_mirror.py
@@ -10,6 +10,7 @@ from unittest import mock
 
 import requests
 from minio.error import S3Error
+from patoolib.util import PatoolError
 from urllib3 import HTTPHeaderDict
 from urllib3.exceptions import ProtocolError
 
@@ -481,6 +482,55 @@ class ObjectMetadataTest(unittest.TestCase):
 
         self.assertIs(ok, True)
         self.assertEqual(client.uploaded, [])
+
+
+class ExtractionFailureTest(unittest.TestCase):
+    def setUp(self):
+        self.dir = tempfile.mkdtemp()
+        self.cwd = os.getcwd()
+        os.chdir(self.dir)
+
+    def tearDown(self):
+        os.chdir(self.cwd)
+        shutil.rmtree(self.dir)
+
+    def _mirror(self, extract):
+        client = _FakeClient()
+        with mock.patch.object(
+            mirror.requests, "get", return_value=_response(b"archive-bytes")
+        ):
+            with mock.patch.object(mirror.patoolib, "extract_archive", extract):
+                ok = mirror.mirror_version(client, BUCKET, TALOS, TALOS["versions"][0])
+        return ok, client
+
+    def test_unreadable_archive_is_reported_not_raised(self):
+        def extract(name, outdir):
+            raise PatoolError("unknown archive format")
+
+        ok, client = self._mirror(extract)
+
+        self.assertIs(ok, False)
+        self.assertEqual(client.uploaded, [])
+
+    def test_archive_without_the_expected_image_is_reported(self):
+        # What gardenlinux actually ships: the archive unpacks to a root
+        # filesystem tree, so the image the mirror_url names never appears.
+        def extract(name, outdir):
+            os.makedirs(os.path.join(outdir, "boot"), exist_ok=True)
+
+        ok, client = self._mirror(extract)
+
+        self.assertIs(ok, False)
+        self.assertEqual(client.uploaded, [])
+
+    def test_failed_extraction_leaves_no_downloaded_archive(self):
+        def extract(name, outdir):
+            raise PatoolError("unknown archive format")
+
+        self._mirror(extract)
+
+        leftovers = [f for f in os.listdir(".") if f != "tmp"]
+        self.assertEqual(leftovers, [])
 
 
 SAMPLE_YML = """\


### PR DESCRIPTION
`contrib/mirror.py` mirrors the image catalog into the `osism` bucket, and it
never checked that what it uploaded was the image the definition describes. Six
defects let it store the wrong bytes, keep them indefinitely, or abort a whole
run on one bad upstream. This fixes them and gives the script its first tests.

Found by reading the script while explaining the mirror step during review of:

- osism/openstack-image-manager#1260

**Nothing in the bucket is wrong today.** All 34 mirrored objects (~28 GB) were
streamed and hashed against their definitions for this change: 31 matched
byte-for-byte and none were corrupt. The only mismatches were three Garden
Linux entries whose *definitions* had drifted, fixed separately on
`gardenlinux-fix-checksums`. So this is preventive work, not a cleanup.

## The defects

| Defect | Consequence |
| --- | --- |
| The download never checked the HTTP status | A dead URL's error page would be written, uploaded under the definition's `mirror_url`, and then never replaced — an existing path is never fetched again, and a later version bump writes elsewhere |
| Connection and mid-transfer failures were unhandled | A refused lookup or dropped transfer aborted the entire run rather than failing one version |
| No request timeout | A mirror that accepts a connection and then stalls hung the run indefinitely |
| `--checksum` only calculated a digest | It hashed with a hardcoded SHA512, logged it, and compared it to nothing, so a corrupted or substituted image was mirrored regardless. Definitions record sha256 or sha512, so the fixed algorithm was often the wrong one |
| An object already in the bucket was skipped on sight | Nothing recorded which definition an object came from, so "present" could not be told from "correct" |
| Unpacking was unguarded | patoolib raising, or the expected image not being there after extraction, killed the run with a traceback |

The rot these depend on is real and routine: CentOS Stream keeps only a handful
of builds online, and the Stream 10 pin in #1260 had already died upstream
before it was refreshed. What has not happened is a mirror run meeting such a
pin — because that step is manual and infrequent, not because the script would
have coped.

## What this does

- Checks the HTTP status before writing anything, and treats a failed name
  lookup, handshake or dropped transfer the same way. Partial files are removed
  so a later run cannot mistake one for a finished download.
- Streams with `iter_content()` rather than copying `response.raw`. Reading raw
  goes straight to urllib3, whose errors are not `requests.RequestException`, so
  a dropped transfer escaped the handler; `iter_content` translates them. It also
  decodes a content-encoded transfer, which raw did not.
- Adds a 30s request timeout, matching `REQUESTS_TIMEOUT` in the manager itself.
- Hashes the file that is about to be uploaded, with the algorithm named in the
  definition, and compares. The mirrored object is what the checksum describes —
  for the nine compressed entries that is the unpacked image, not the archive:
  `contrib/update-gardenlinux.py` records the digest of the extracted image, and
  the manager reads `mirror_url` in preference to `url`.
- Records the verified checksum on the object as user metadata, and compares it
  against the definition on later runs. A mismatch fails that version and leaves
  the object untouched, since it means either the object is wrong or a definition
  changed under a fixed version — overwriting would hide the second.
- Treats a failed unpack as a failed version rather than a dead run. Garden Linux
  ships a rootfs `tar.xz` with no disk image inside, so that path raises
  `FileNotFoundError` today.
- Reports failures per version and exits non-zero at the end, matching how the
  manager handles per-image failures, so one bad upstream no longer blocks the
  rest of the catalog.

## Deliberate abstentions

- Metadata is written **only** when the run actually verified the bytes. With
  `--no-checksum`, or `--no-download` over a file left by an earlier run, nothing
  is recorded rather than asserting something unproven that a later run trusts.
- A version with no checksum, which the schema permits, is mirrored with a
  warning rather than failed.
- Every object in the bucket today predates metadata recording, so the first run
  after this lands will warn for all 34 and confirm nothing about them. They are
  skipped as present, exactly as now.

## Scope

The metadata establishes *which definition an object was uploaded for*, not that
the bytes in the bucket still hash to that value. Detecting bucket-side
corruption needs a re-download pass, which this does not add — though the
one-off audit above found nothing for it to catch.

## Structure

Seven commits, each independently green. The first is a pure extraction: all of
this logic lived in one ~200-line `main()`, which is why the file had no tests.
`mirror_paths()` and `mirror_version()` are now testable with a fake object
store client.

## Testing

- `tox -e test -- test/unit` passes: 104 tests, up from 74, with 30 new ones
  covering the naming rules, the download and unpack failure paths, and the
  metadata round trip.
- flake8, black and mypy clean at every one of the seven commits, not just the tip.
- Written test-first throughout. The fake client stores metadata the way minio
  does (`X-Amz-Meta-` prefixed, read back from a case-insensitive header mapping)
  and the broken-transfer fake implements `stream()` like a real urllib3
  response, so the tests exercise the mechanisms production uses rather than
  mocks that would pass either way.
- Not covered: nothing here ran against a real bucket. The metadata round trip is
  exercised against the fake only.

## Related

While auditing the bucket for this change, the Garden Linux updater turned out
to be broken and reporting success: `contrib/update-gardenlinux.py` looks for a
qcow2 inside the release archive, upstream ships none, and the abort path exits
0 — so its daily workflow has been a silent no-op. That is tracked separately
and is not addressed here.
