### PR TITLE
Fix wrong Garden Linux checksums

### DIFF
--- a/etc/images/gardenlinux.yml
+++ b/etc/images/gardenlinux.yml
@@ -27,17 +27,17 @@ images:
       - version: '1592.14'
         url: https://github.com/gardenlinux/gardenlinux/releases/download/1592.14/openstack-gardener_prod-amd64-1592.14-730f446c.tar.xz
         mirror_url: https://nbg1.your-objectstorage.com/osism/openstack-images/gardenlinux/1592.14/openstack-gardener_prod-amd64-1592.14-730f446c.qcow2
-        checksum: "sha256:71b5a12e172d35bdbb85fe3861b2a35e7dd6b242c8c0a4b986a1c341340e4e23"
+        checksum: "sha256:d88da40ad12dd501ebea6af1ef80f4896cbc5ebd381005ef42246108bea3b1af"
         build_date: 2025-09-17
       - version: '1877.5'
         url: https://github.com/gardenlinux/gardenlinux/releases/download/1877.5/openstack-gardener_prod-amd64-1877.5-7a907e4e.tar.xz
         mirror_url: https://nbg1.your-objectstorage.com/osism/openstack-images/gardenlinux/1877.5/openstack-gardener_prod-amd64-1877.5-7a907e4e.qcow2
-        checksum: "sha256:1ad90c202e360f0893525a081dd381dcdfbb42242da2c249bad3284fef6030a7"
+        checksum: "sha256:a968b3497a5935d6f6b8000499a0fc206bbbf49712f7a660a6b7c43c9cac102b"
         build_date: 2025-10-17
       - version: '1877.6'
         url: https://github.com/gardenlinux/gardenlinux/releases/download/1877.6/openstack-gardener_prod-amd64-1877.6-48d68617.tar.xz
         mirror_url: https://nbg1.your-objectstorage.com/osism/openstack-images/gardenlinux/1877.6/openstack-gardener_prod-amd64-1877.6-48d68617.qcow2
-        checksum: "sha256:1ad90c202e360f0893525a081dd381dcdfbb42242da2c249bad3284fef6030a7"
+        checksum: "sha256:32fd15837df5745eea63c9449896f46bf3884c8bc2c8af5a82c284dd75cf63a1"
         build_date: 2025-11-04
       - version: '1877.7'
         url: https://github.com/gardenlinux/gardenlinux/releases/download/1877.7/openstack-gardener_prod-amd64-1877.7-5282bd31.tar.xz


### PR DESCRIPTION
Three Garden Linux versions record a checksum that does not match the image
their `mirror_url` points at, so verifying a download of any of them fails.

| Version | Recorded | Actual | Origin of the wrong value |
| --- | --- | --- | --- |
| 1592.14 | `71b5a12e…` | `d88da40a…` | entered in #973 |
| 1877.5 | `1ad90c20…` | `a968b349…` | entered in #973 |
| 1877.6 | `1ad90c20…` | `32fd1583…` | copied from 1877.5 in #984 |

1877.5 and 1877.6 carrying the same digest cannot be right for two different
builds; `git log -S` traces the duplication to the commit that added 1877.6.

## How the values were established

Every mirrored object in the bucket was streamed and hashed against its
definition — 34 objects, ~28 GB. These three were the only mismatches; the
remaining 31 matched byte-for-byte. The four other Garden Linux versions
already agreed and are untouched.

The objects themselves are intact. For 1877.6 the `.sha256` sidecar that
`contrib/mirror.py` uploaded alongside the image reads `32fd1583…` — exactly
what the object hashes to today — so the file has not changed since upload. The
definitions drifted, the bucket did not.

## What this does and does not prove

Garden Linux releases ship a root filesystem `tar.xz` and no disk image at all,
so the mirrored object is the only artifact these digests can describe, and for
the two versions without a sidecar there is nothing to check it against. The new
values guard the download of a stored image; they do not establish that the
stored image is the build its version names.

That same missing reference is why `contrib/update-gardenlinux.py` cannot
refresh these entries: it looks for a qcow2 inside the release archive, finds
none, and gives up without writing anything — while still exiting 0, so its
daily workflow reports success. That is filed separately and not addressed here.

Nothing an operator uses is affected today: every Garden Linux entry is
`enable: false`, and `osism manage image gardenlinux` builds its definitions
from OSISM object storage rather than from `etc/images`.

## Related

- osism/openstack-image-manager#1269

`tox -- --check-only` and yamllint pass.
