### PR TITLE
Make Cirros mirrorable to the object store

### DIFF
--- a/contrib/mirror.py
+++ b/contrib/mirror.py
@@ -384,6 +384,7 @@ def main(
             (
                 "almalinux",
                 "centos",
+                "cirros",
                 "debian",
                 "flatcar",
                 "gardenlinux",

--- a/etc/images/cirros.yml
+++ b/etc/images/cirros.yml
@@ -3,6 +3,7 @@ images:
 
   - name: Cirros
     enable: true
+    shortname: cirros
     format: qcow2
     login: cirros
     password: gocubsgo
@@ -27,9 +28,11 @@ images:
     versions:
       - version: '0.6.2'
         url: https://github.com/cirros-dev/cirros/releases/download/0.6.2/cirros-0.6.2-x86_64-disk.img
+        mirror_url: https://nbg1.your-objectstorage.com/osism/openstack-images/cirros/0.6.2-cirros.qcow2
         checksum: "sha256:07e44a73e54c94d988028515403c1ed762055e01b83a767edf3c2b387f78ce00"
         build_date: 2023-05-30
       - version: '0.6.3'
         url: https://github.com/cirros-dev/cirros/releases/download/0.6.3/cirros-0.6.3-x86_64-disk.img
+        mirror_url: https://nbg1.your-objectstorage.com/osism/openstack-images/cirros/0.6.3-cirros.qcow2
         checksum: "sha256:7d6355852aeb6dbcd191bcda7cd74f1536cfe5cbf8a10495a7283a8396e4b75b"
         build_date: 2024-09-26


### PR DESCRIPTION
Cirros is the only image definition without a `mirror_url`, so no mirrored copy
of it exists in the object store and there is no way to serve it from a local
mirror. An air-gapped site therefore has no route to the image most commonly
used to check that a cloud works at all.

## Why three changes in one commit

They cannot land separately, because `contrib/mirror.py`:

- skips an image that has no `shortname` (`:380-381`),
- skips a version that has no `mirror_url` (`:399-400`), and
- derives the upload destination *from* `mirror_url` (`:60`).

The definition is thus the **input** to mirroring rather than its output: the
destination has to be declared before the tool can place anything there. So this
adds `shortname: cirros`, a `mirror_url` per pinned version, and `cirros` to the
shortname allow-list.

## Destinations

Derived by calling the tool's own `mirror_paths()` rather than composed by hand,
so the declared and computed paths cannot disagree:

```
0.6.2 -> openstack-images/cirros/0.6.2-cirros.qcow2
0.6.3 -> openstack-images/cirros/0.6.3-cirros.qcow2
```

Both are flat, with no version directory. `mirror_paths()` adds one only for
`flatcar`, or when the *source* extension is `.bz2/.zip/.xz/.gz`; Cirros
publishes an uncompressed `.img`.

`url` is deliberately left untouched — it is what sets the `image_source`
property, so upstream provenance stays recorded even when the bytes are fetched
from a mirror.

## Follow-up

This change only makes the upload possible. Performing it is a separate
credentialed step (`tox -e mirror`), and until that runs the new `mirror_url`s
point at objects that do not exist yet. Worth landing before the next mirror
pass so Cirros rides it.

Precedent for the allow-list entry, which also states the general rule that
registering a handler is not sufficient on its own:

- osism/openstack-image-manager#1260

## Testing

- `tox -- --check-only` passes (schema).
- `tox -e test -- test/unit` passes, 74 tests.
- `yamllint`, `python-black`, `flake8`, `mypy` clean over the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)