### PR TITLE
Automate the image mirror step

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -13,6 +13,32 @@
       - .github/workflows/*
       - etc/images/*
 
+- job:
+    name: openstack-image-manager-check-upstream
+    description: |
+      Fail while any in-scope catalog version has neither a retrievable
+      mirror nor a retrievable upstream. This walks the whole catalog, not
+      just what the change under review touched, so a red result here is
+      not necessarily caused by this change -- it can equally be an
+      already-rotted pin elsewhere in the catalog. A version that is merely
+      not mirrored yet, with upstream still reachable, is fine here -- the
+      upload happens after the merge.
+    run: playbooks/check-mirror.yml
+    files:
+      - '^etc/images/.*\.yml$'
+    vars:
+      check_mirror_accept: [0, 3]
+
+- job:
+    name: openstack-image-manager-check-mirror
+    description: |
+      Fail while the catalog references an object the store cannot serve.
+      This is the only signal that survives the upload job being broken,
+      expired, or not yet wired.
+    run: playbooks/check-mirror.yml
+    vars:
+      check_mirror_accept: [0]
+
 - project:
     merge-mode: squash-merge
     default-branch: main
@@ -20,6 +46,7 @@
       jobs:
         - flake8
         - mypy
+        - openstack-image-manager-check-upstream
         - openstack-image-manager-integration-test
         - python-black
         - tox:
@@ -31,6 +58,7 @@
       jobs:
         - flake8
         - mypy
+        - openstack-image-manager-check-mirror
         - openstack-image-manager-integration-test
         - python-black
         - tox:

--- a/README.md
+++ b/README.md
@@ -49,3 +49,149 @@ path downloads the image to a temporary directory on the host running
 `openstack-image-manager`, so that filesystem needs room for the full image
 (e.g. ~345 MB for the octavia amphora image). A free-space preflight aborts before
 downloading if the temporary filesystem is too small.
+
+## Mirroring images to the object store
+
+Versions that carry a `mirror_url` are expected to be retrievable from the
+`osism` bucket on `nbg1.your-objectstorage.com` — `mirror_url`, not `url`, is
+what the manager hands to Glance for import.
+
+**How an object gets into the store.** Once a definition change merges to
+`main`, the `post` pipeline is designed to run the
+`openstack-image-manager-mirror-images` job: `tox -e mirror` uploads every
+object the catalog references that the store lacks, and the same job then
+runs `tox -e check-mirror` to confirm each object is anonymously retrievable.
+`periodic-daily` re-runs the check every day and, once the upload job is
+enabled there too, re-uploads anything that should be present but is not
+retrievable — including an object that arrived by some other route. As of
+this writing `openstack-image-manager-mirror-images` is not yet committed
+(see below); only the check half of this lifecycle is live.
+
+**Reading a red check.** `tox -e check-mirror` (`contrib/check_mirror.py`)
+walks the catalog and reports its findings in two classes:
+
+- *pending mirror* — the mirror is not retrievable while upstream still is,
+  so an upload is owed.
+- *unmirrorable* — neither the mirror nor upstream is retrievable, so the
+  pinned `url` must be updated before any upload can fix this.
+
+"Not retrievable" is the strongest claim available: the object store answers
+`403` both for an object that was never uploaded and for one that exists but
+lost its public read permission, and the fix differs (an upload versus a
+permissions change) — so neither the checker nor this README calls an object
+"missing" or "absent".
+
+`openstack-image-manager-check-upstream` walks the *whole* catalog, not only
+what the change under review touched. So once any one version is both
+unmirrored and its upstream `url` has rotted, that single pin blocks the
+`check` pipeline for every subsequent PR that touches `etc/images/*.yml` —
+including renovate's automated ones — until it is fixed, regardless of what
+those PRs actually changed. The PR that bumps the dead pin is what clears it
+again.
+
+Exit codes of `tox -e check-mirror`: `0` clean, `1` at least one unmirrorable
+version, `2` the run reached no verdict (an operational failure, or a usage
+error — typer's own exit code for a usage error is also `2`), `3` pending
+mirror only.
+
+The mirror is probed twice: a non-following `HEAD`, reproducing the gate that
+`main.py:991` applies before import (which accepts only `200` and `302`), and
+a ranged `GET` with redirects followed, requiring that bytes actually arrive
+(`200` or `206`). A healthy object reads `HEAD 200, GET 206`. Upstream is
+probed once, with a ranged `GET` that follows redirects, because only
+`contrib/mirror.py` fetches it, and that fetch follows redirects too.
+
+**Running the mirror by hand**, for someone holding the object store
+credentials:
+
+```console
+$ export MINIO_ACCESS_KEY=... MINIO_SECRET_KEY=...
+$ tox -e mirror
+$ tox -e check-mirror
+```
+
+**Triggering the Zuul job manually.** There is no `workflow_dispatch`
+equivalent. Enqueueing `openstack-image-manager-mirror-images` (once it
+exists, see below) takes Zuul admin rights and `zuul-client enqueue-ref`
+against the `post` pipeline for `osism/openstack-image-manager` — take the
+exact invocation from `zuul-client enqueue-ref --help`.
+
+**Enabling the upload job once the keys exist.** The two keys are the access
+key and secret key for the `osism` bucket on `nbg1.your-objectstorage.com`.
+Encrypt them for this project with `zuul-client encrypt` (check the flags
+against `zuul-client encrypt --help`; the project's public key is served by
+the Zuul API on the OSISM Zuul, `https://zuul.services.osism.tech` — its
+build URLs are of the form
+`https://zuul.services.osism.tech/t/osism/buildset/<id>`, but this README does
+not assert the exact key-endpoint path, so check `zuul-client encrypt --help`
+or the Zuul documentation for that), then add the block below to
+`.zuul.yaml`. The secret name, data keys and binding deliberately match the
+job removed in `3c21cc5`, so any earlier runbook for it still applies.
+
+> **Warning:** do not commit this block as-is. A placeholder
+> `!encrypted/pkcs1-oaep` value, like the ones below, is a Zuul
+> **configuration syntax error for the whole project** — it breaks every
+> pipeline for this repo, not just this job. Commit it only once the
+> placeholders are replaced with real encrypted values.
+
+```yaml
+- secret:
+    name: SECRET_OPENSTACK_IMAGE_MANAGER
+    data:
+      ACCESS_KEY: !encrypted/pkcs1-oaep
+        - <output of zuul-client encrypt>
+      SECRET_KEY: !encrypted/pkcs1-oaep
+        - <output of zuul-client encrypt>
+
+- semaphore:
+    name: semaphore-openstack-image-manager-mirror-images
+    max: 1
+
+- job:
+    name: openstack-image-manager-mirror-images
+    description: |
+      Upload every object the catalog references and the store lacks, then
+      confirm each one is anonymously retrievable.
+    semaphores:
+      - name: semaphore-openstack-image-manager-mirror-images
+    allowed-projects: osism/openstack-image-manager
+    nodeset: ubuntu-noble-large
+    timeout: 5400
+    pre-run: playbooks/pre-mirror-images.yml
+    run: playbooks/mirror-images.yml
+    secrets:
+      - name: secret
+        secret: SECRET_OPENSTACK_IMAGE_MANAGER
+```
+
+...plus the job added to the `post` pipeline (branch `main`) and to
+`periodic-daily`, alongside the existing `openstack-image-manager-check-mirror`
+job there. `.zuul.yaml` has no `post:` pipeline section today, so this adds
+one to the `project:` stanza, shaped like its existing `check:` and
+`periodic-daily:` sections:
+
+```yaml
+- project:
+    merge-mode: squash-merge
+    default-branch: main
+    check:
+      jobs:
+        - ...             # unchanged
+    post:
+      jobs:
+        - openstack-image-manager-mirror-images:
+            branches: main
+    periodic-daily:
+      jobs:
+        - flake8
+        - mypy
+        - openstack-image-manager-check-mirror
+        - openstack-image-manager-integration-test
+        - openstack-image-manager-mirror-images
+        - python-black
+        - tox:
+            vars:
+              tox_envlist: test
+              tox_extra_args: -- test/unit
+        - yamllint
+```

--- a/contrib/check_mirror.py
+++ b/contrib/check_mirror.py
@@ -1,0 +1,253 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Read-only check of the object store against the catalog. Every version the
+# mirror step handles must be retrievable from its mirror_url, because that is
+# what main.py hands Glance -- and it is fetched with no credentials, so that
+# is how this probes. A gap is reported as pending mirror when upstream is
+# still reachable, and as unmirrorable when it is not.
+
+import sys
+import time
+from dataclasses import dataclass, field
+
+import requests
+import typer
+from loguru import logger
+
+from contrib.mirror import iter_mirrorable
+
+app = typer.Typer()
+
+HTTP_TIMEOUT = 30
+
+# A full pass is close to 80 requests against essentially one host, so a
+# single TLS reset or stalled connection must not fail the whole run. Retry
+# only a transport failure -- an HTTP status is a verdict and is never
+# retried.
+RETRY_ATTEMPTS = 3
+RETRY_SLEEP_SECONDS = (1, 2)
+
+# What a fetch of the bytes may answer: 200 for a body, 206 when the server
+# honours the one-byte range. Following redirects and requiring this at the end
+# of the chain is what stops a 302 to a gone target counting as retrievable --
+# the gardenlinux upstream urls really do answer 302.
+FETCHED = (200, 206)
+# What main.py:991 accepts from its own non-following HEAD of the url it is
+# about to hand Glance. Applies to mirror_url only: a 301 there fails the
+# import however servable the bytes are. Upstream faces no such gate, since
+# only mirror.py fetches it, with allow_redirects=True (in mirror_version() in
+# contrib/mirror.py).
+MANAGER_ACCEPTS = (200, 302)
+
+EXIT_CLEAN = 0
+EXIT_UNMIRRORABLE = 1
+# 2 is operational: it is check_updates.py's convention for a run that reached
+# no verdict, and typer's own exit code for a usage error. Pending is 3 so that
+# a mistyped option can never be read as a verdict.
+EXIT_OPERATIONAL = 2
+EXIT_PENDING = 3
+
+
+class OperationalError(Exception):
+    """The run could not reach a verdict."""
+
+
+@dataclass(frozen=True)
+class Finding:
+    name: str
+    shortname: str
+    version: str
+    mirror_url: str
+    mirror_status: str
+    upstream_status: str
+
+
+@dataclass
+class Report:
+    pending: list = field(default_factory=list)
+    unmirrorable: list = field(default_factory=list)
+
+    def is_empty(self):
+        return not self.pending and not self.unmirrorable
+
+
+def _chain(response):
+    """Describe the status chain, e.g. '403' or '302 -> 200'."""
+    codes = [str(hop.status_code) for hop in response.history]
+    codes.append(str(response.status_code))
+    return " -> ".join(codes)
+
+
+def _with_retries(url, probe):
+    """Run probe() up to RETRY_ATTEMPTS times, retrying only a transport failure.
+
+    An HTTP status is a verdict and is returned immediately, never retried.
+    Only requests.RequestException -- a connection reset, timeout, or similar
+    transport hiccup -- triggers a retry, with a short backoff in between.
+    OperationalError is raised only once every attempt has failed.
+    """
+    for attempt in range(RETRY_ATTEMPTS):
+        try:
+            return probe()
+        except requests.RequestException as exc:
+            if attempt == RETRY_ATTEMPTS - 1:
+                raise OperationalError(f"cannot probe {url}: {exc}")
+            time.sleep(RETRY_SLEEP_SECONDS[attempt])
+
+
+def fetchable(url):
+    """Read one byte of url's body, following redirects.
+
+    Returns (bytes arrived, status chain as text). Only a FETCHED status is
+    read at all -- a 403's error payload is irrelevant. A FETCHED status with
+    an empty body means the server answered but never sent bytes, which is
+    not retrievable either; the returned text is then annotated, e.g.
+    "206 (empty body)". A transport failure while reading the body is
+    operational, same as one while reading the headers -- it says nothing
+    about the object. An HTTP status is a verdict, including 403, which is
+    what Hetzner answers for a key that does not exist.
+    """
+
+    def probe():
+        response = requests.get(
+            url,
+            headers={"Range": "bytes=0-0"},
+            allow_redirects=True,
+            stream=True,
+            timeout=HTTP_TIMEOUT,
+        )
+        try:
+            status = _chain(response)
+            arrived = response.status_code in FETCHED
+            if arrived:
+                chunk = next(response.iter_content(chunk_size=1), b"")
+                if not chunk:
+                    arrived = False
+                    status = f"{status} (empty body)"
+        finally:
+            response.close()
+        return arrived, status
+
+    return _with_retries(url, probe)
+
+
+def accepted_by_manager(url):
+    """Reproduce main.py's own pre-import check: a non-following HEAD.
+
+    Returns (accepted, status). Only meaningful for a url the manager hands
+    Glance, i.e. mirror_url.
+    """
+
+    def probe():
+        response = requests.head(url, allow_redirects=False, timeout=HTTP_TIMEOUT)
+        return response.status_code in MANAGER_ACCEPTS, str(response.status_code)
+
+    return _with_retries(url, probe)
+
+
+def probe_mirror(url):
+    """Both conditions the mirrored object has to satisfy.
+
+    The manager refuses a status outside MANAGER_ACCEPTS before it ever starts
+    the import, and Glance then has to actually receive bytes. Neither implies
+    the other: a healthy object answers 200 to HEAD and 206 to a ranged GET.
+    """
+    accepted, head_status = accepted_by_manager(url)
+    arrived, get_status = fetchable(url)
+
+    status = f"HEAD {head_status}, GET {get_status}"
+    if accepted and arrived:
+        return True, status
+    if arrived and not accepted:
+        return False, f"{status} (the manager refuses a {head_status})"
+    return False, status
+
+
+def evaluate(images_dir):
+    report = Report()
+    for image, version in iter_mirrorable(images_dir):
+        retrievable, status = probe_mirror(version["mirror_url"])
+        if retrievable:
+            logger.debug(f"{image['shortname']} {version['version']}: {status}")
+            continue
+
+        # Upstream is fetched only by mirror_version() in contrib/mirror.py,
+        # which follows redirects, so any chain ending in bytes counts -- a
+        # 301 here is not a problem.
+        upstream_retrievable, upstream_status = fetchable(version["url"])
+        finding = Finding(
+            name=image["name"],
+            shortname=image["shortname"],
+            version=str(version["version"]),
+            mirror_url=version["mirror_url"],
+            mirror_status=status,
+            upstream_status=upstream_status,
+        )
+        if upstream_retrievable:
+            report.pending.append(finding)
+        else:
+            report.unmirrorable.append(finding)
+    return report
+
+
+def render(report):
+    lines = []
+    if report.unmirrorable:
+        lines += [
+            "Unmirrorable -- mirror not retrievable, upstream not retrievable "
+            "either, so no mirror run can fill these:",
+            "",
+        ]
+        for finding in report.unmirrorable:
+            lines.append(
+                f"  {finding.name} {finding.shortname} {finding.version}: "
+                f"mirror {finding.mirror_status}, upstream {finding.upstream_status}"
+            )
+            lines.append(f"    {finding.mirror_url}")
+        lines.append("")
+    if report.pending:
+        # Never "missing" or "no copy": a 403 cannot tell absence apart from an
+        # object that exists and lost its public read permission.
+        lines += [
+            "Pending mirror -- mirror not retrievable, upstream retrievable:",
+            "",
+        ]
+        for finding in report.pending:
+            lines.append(
+                f"  {finding.name} {finding.shortname} {finding.version}: "
+                f"mirror {finding.mirror_status}"
+            )
+            lines.append(f"    {finding.mirror_url}")
+        lines.append("")
+    return ("\n".join(lines).strip() + "\n") if lines else ""
+
+
+@app.command()
+def main(
+    images: str = typer.Option("etc/images/", help="Directory with image definitions"),
+    debug: bool = typer.Option(False, help="Enable debug logging"),
+):
+    logger.remove()
+    logger.add(sys.stderr, level="DEBUG" if debug else "INFO")
+
+    try:
+        report = evaluate(images)
+    except typer.Exit:
+        raise
+    except Exception as exc:  # noqa: BLE001 - any failure here reached no verdict
+        logger.error(f"operational failure: {exc}")
+        raise typer.Exit(code=EXIT_OPERATIONAL)
+
+    if report.is_empty():
+        logger.info("every mirrored object the catalog references is retrievable")
+        raise typer.Exit(code=EXIT_CLEAN)
+
+    sys.stdout.write(render(report))
+
+    if report.unmirrorable:
+        raise typer.Exit(code=EXIT_UNMIRRORABLE)
+    raise typer.Exit(code=EXIT_PENDING)
+
+
+if __name__ == "__main__":
+    app()

--- a/contrib/mirror.py
+++ b/contrib/mirror.py
@@ -7,6 +7,7 @@ import re
 import requests
 import shutil
 import sys
+import tempfile
 import typer
 import yaml
 
@@ -169,15 +170,23 @@ def mirror_version(
                         os.remove(source_filename)
                     return False
 
+            # Extract into a directory of this version's own, and drop it on
+            # every path out. patoolib may produce archive members besides the
+            # image, or fail partway with bytes already written; both are a
+            # full image's worth of disk that nothing else removes.
+            extract_dir = None
             try:
                 if source_fileextension in [".bz2", ".zip", ".xz", ".gz"]:
                     logger.info(f"Decompressing {source_filename}")
                     Path("tmp").mkdir(exist_ok=True)
+                    extract_dir = tempfile.mkdtemp(dir="tmp")
                     patoolib.extract_archive(
-                        os.path.basename(source_filename), outdir="tmp"
+                        os.path.basename(source_filename), outdir=extract_dir
                     )
                     os.remove(source_filename)
-                    shutil.copy(os.path.join("tmp", mirror_filename), mirror_filename)
+                    shutil.move(
+                        os.path.join(extract_dir, mirror_filename), mirror_filename
+                    )
                 else:
                     os.rename(source_filename, mirror_filename)
             except (PatoolError, OSError) as exc:
@@ -186,6 +195,9 @@ def mirror_version(
                     if isfile(leftover):
                         os.remove(leftover)
                 return False
+            finally:
+                if extract_dir:
+                    shutil.rmtree(extract_dir, ignore_errors=True)
 
             if checksum:
                 expected = version.get("checksum")

--- a/contrib/mirror.py
+++ b/contrib/mirror.py
@@ -33,6 +33,22 @@ REQUESTS_TIMEOUT = 30
 UPSTREAM_CHECKSUM_KEY = "upstream-checksum"
 UPSTREAM_CHECKSUM_HEADER = "x-amz-meta-upstream-checksum"
 
+# Shortnames whose images are mirrored. Anything else in the catalog is served
+# from upstream only. Extending this is a one-line change here; it is read, not
+# restated, by contrib/check_mirror.py.
+MIRRORED_SHORTNAME_PREFIXES = (
+    "almalinux",
+    "centos",
+    "debian",
+    "flatcar",
+    "gardenlinux",
+    "opensuse",
+    "opnsense",
+    "rocky",
+    "talos",
+    "ubuntu",
+)
+
 app = typer.Typer(add_completion=False)
 
 
@@ -313,6 +329,42 @@ def mirror_version(
     return True
 
 
+def read_image_definitions(images_dir):
+    """Every image entry from every definition file in images_dir."""
+    all_images = []
+    for name in sorted(listdir(images_dir)):
+        if not name.endswith(".yml"):
+            continue
+        path = join(images_dir, name)
+        if not isfile(path):
+            continue
+        logger.debug(f"Adding {name} to the list of files")
+        with open(path) as fp:
+            data = yaml.load(fp, Loader=yaml.SafeLoader)
+        for image in data.get("images") or []:
+            all_images.append(image)
+    return all_images
+
+
+def iter_mirrorable(images_dir):
+    """Yield (image, version) for every version the mirror step handles.
+
+    This is the mirror's scope, and the only definition of it: an allow-listed
+    shortname, and a version carrying both url and mirror_url, since
+    mirror_paths() derives the destination from mirror_url. `enable` is
+    deliberately not consulted -- a disabled image stays mirrored.
+    """
+    for image in read_image_definitions(images_dir):
+        if "versions" not in image or "shortname" not in image:
+            continue
+        if not image["shortname"].startswith(MIRRORED_SHORTNAME_PREFIXES):
+            continue
+        for version in image["versions"]:
+            if "url" not in version or "mirror_url" not in version:
+                continue
+            yield image, version
+
+
 @app.command()
 def main(
     debug: bool = typer.Option(False, "--debug", help="Enable debug logging"),
@@ -366,62 +418,21 @@ def main(
         logger.error(f"Create bucket '{minio_bucket}' first")
         sys.exit(1)
 
-    onlyfiles = []
-    for f in listdir(images):
-        if isfile(join(images, f)):
-            logger.debug(f"Adding {f} to the list of files")
-            onlyfiles.append(f)
-
-    all_images = []
-    for file in [x for x in onlyfiles if x.endswith(".yml")]:
-        logger.info(f"Processing file {file}")
-        with open(join(images, file)) as fp:
-            data = yaml.load(fp, Loader=yaml.SafeLoader)
-            for image in data.get("images"):
-                logger.debug(f"Adding {image['name']} to the list of images")
-                all_images.append(image)
-
     failed = []
 
-    for image in all_images:
-        logger.info(f"Processing image {image['name']}")
+    for image, version in iter_mirrorable(images):
+        logger.info(f"Processing image {image['name']} {version['version']}")
 
-        if "versions" not in image:
-            continue
-
-        if "shortname" not in image:
-            continue
-
-        if not image["shortname"].startswith(
-            (
-                "almalinux",
-                "centos",
-                "debian",
-                "flatcar",
-                "gardenlinux",
-                "opensuse",
-                "opnsense",
-                "rocky",
-                "talos",
-                "ubuntu",
-            )
+        if not mirror_version(
+            client,
+            minio_bucket,
+            image,
+            version,
+            download=download,
+            checksum=checksum,
+            upload=upload,
         ):
-            continue
-
-        for version in image["versions"]:
-            if "url" not in version or "mirror_url" not in version:
-                continue
-
-            if not mirror_version(
-                client,
-                minio_bucket,
-                image,
-                version,
-                download=download,
-                checksum=checksum,
-                upload=upload,
-            ):
-                failed.append(f"{image['name']} {version['version']}")
+            failed.append(f"{image['name']} {version['version']}")
 
     if failed:
         logger.error(f"Failed to mirror {len(failed)} image version(s):")

--- a/playbooks/check-mirror.yml
+++ b/playbooks/check-mirror.yml
@@ -1,0 +1,36 @@
+---
+- name: Check the object store against the catalog
+  hosts: all
+
+  # check_mirror_accept is supplied by the job and deliberately has NO default
+  # here. Zuul passes job vars into the inventory as variables of the `all`
+  # group, and Ansible ranks play vars above inventory vars -- so a default in
+  # this section would silently outrank every job's setting, and the strict
+  # daily job would tolerate a pending mirror, losing the whole signal.
+  vars:
+    zuul_work_dir: "{{ zuul.project.src_dir }}"
+
+  roles:
+    - role: ensure-tox
+
+  tasks:
+    - name: Require the pipeline to state which exit codes it accepts
+      ansible.builtin.assert:
+        that:
+          - check_mirror_accept is defined
+          - check_mirror_accept | type_debug == "list"
+        fail_msg: >-
+          check_mirror_accept must be set by the job, e.g. [0, 3] in check and
+          [0] in periodic-daily.
+
+    # 0 is clean, 3 is "not mirrored yet" -- normal for a change that adds a
+    # version, a defect once it is on main. Everything else fails: 1 is an
+    # unmirrorable pin, 2 is a run that reached no verdict, and an unlisted
+    # code is a crash.
+    - name: Probe every mirrored object the catalog references
+      ansible.builtin.command:
+        cmd: "{{ tox_executable }} -e check-mirror"
+        chdir: "{{ zuul_work_dir }}"
+      register: check_mirror
+      changed_when: false
+      failed_when: check_mirror.rc not in check_mirror_accept

--- a/playbooks/mirror-images.yml
+++ b/playbooks/mirror-images.yml
@@ -1,0 +1,48 @@
+---
+- name: Mirror images to the object store
+  hosts: all
+
+  vars:
+    zuul_work_dir: "{{ zuul.project.src_dir }}"
+
+  tasks:
+    # A wrong secret name or binding leaves secret.ACCESS_KEY/SECRET_KEY
+    # undefined, and no_log below would otherwise censor Ansible's own
+    # "undefined variable" message -- an unexplained failure on the very
+    # first run of a job nobody has ever run. no_log here too, so no value
+    # can leak through the assert itself; fail_msg is a literal string, so
+    # the reason still survives.
+    - name: Require the object store credentials to be bound
+      ansible.builtin.assert:
+        that:
+          - secret.ACCESS_KEY is defined
+          - secret.SECRET_KEY is defined
+        fail_msg: >-
+          secret.ACCESS_KEY and secret.SECRET_KEY must both be set. Check
+          that this job binds the SECRET_OPENSTACK_IMAGE_MANAGER secret
+          and that it carries both the ACCESS_KEY and SECRET_KEY data keys.
+      no_log: true
+
+    # no_log matches the credential handling of the job removed in 3c21cc5.
+    # The verification task below is deliberately not silenced, so a failure
+    # still says which object is wrong.
+    - name: Upload every object the catalog references and the store lacks
+      ansible.builtin.command:
+        cmd: "{{ tox_executable }} -e mirror"
+        chdir: "{{ zuul_work_dir }}"
+      environment:
+        MINIO_ACCESS_KEY: "{{ secret.ACCESS_KEY }}"
+        MINIO_SECRET_KEY: "{{ secret.SECRET_KEY }}"
+      changed_when: true
+      no_log: true
+
+    # mirror.py verifies the download before upload and, on a later run, the
+    # object's recorded checksum -- both through the authenticated client.
+    # Nothing checks that Glance can fetch the object anonymously. This does.
+    - name: Confirm every object is anonymously retrievable
+      ansible.builtin.command:
+        cmd: "{{ tox_executable }} -e check-mirror"
+        chdir: "{{ zuul_work_dir }}"
+      register: verify_mirror
+      changed_when: false
+      failed_when: verify_mirror.rc != 0

--- a/playbooks/pre-mirror-images.yml
+++ b/playbooks/pre-mirror-images.yml
@@ -1,0 +1,6 @@
+---
+- name: Run preparations
+  hosts: all
+
+  roles:
+    - role: ensure-tox

--- a/test/unit/test_check_mirror.py
+++ b/test/unit/test_check_mirror.py
@@ -1,0 +1,506 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import io
+import os
+import shutil
+import tempfile
+import unittest
+from unittest import mock
+
+import requests
+import typer
+from urllib3.exceptions import ProtocolError
+
+import contrib.check_mirror as cm
+
+CATALOG = """\
+---
+images:
+  - name: Ubuntu 24.04
+    shortname: ubuntu-24.04
+    versions:
+      - version: '20260108'
+        url: https://upstream.test/ubuntu-24.04.img
+        mirror_url: https://object.test/osism/openstack-images/ubuntu-24.04/a.qcow2
+  - name: AlmaLinux 10
+    shortname: almalinux-10
+    versions:
+      - version: '20260526'
+        url: https://upstream.test/almalinux-10.qcow2
+        mirror_url: https://object.test/osism/openstack-images/almalinux-10/b.qcow2
+"""
+
+MIRROR_A = "https://object.test/osism/openstack-images/ubuntu-24.04/a.qcow2"
+MIRROR_B = "https://object.test/osism/openstack-images/almalinux-10/b.qcow2"
+UPSTREAM_A = "https://upstream.test/ubuntu-24.04.img"
+UPSTREAM_B = "https://upstream.test/almalinux-10.qcow2"
+
+
+def _response(status, chain=(), body=b"\x00"):
+    """A real requests.Response, optionally behind a redirect history.
+
+    Defaults to a nonempty body: fetchable() now reads a byte from a FETCHED
+    response, and redirect hops are never read so their bodies stay empty.
+    """
+    response = requests.Response()
+    response.status_code = status
+    response.raw = io.BytesIO(body)
+    for code in chain:
+        hop = requests.Response()
+        hop.status_code = code
+        hop.raw = io.BytesIO(b"")
+        response.history.append(hop)
+    return response
+
+
+def _get(statuses):
+    """Stand in for requests.get, answering per URL.
+
+    A value is either a status, or a (final status, redirect chain before it)
+    tuple, optionally followed by a body (default: a nonempty stand-in byte).
+    A url the test did not list raises KeyError, so every probe a test expects
+    has to be spelled out.
+    """
+
+    def get(url, **kwargs):
+        entry = statuses[url]
+        if isinstance(entry, tuple):
+            status, chain = entry[0], entry[1]
+            body = entry[2] if len(entry) > 2 else b"\x00"
+        else:
+            status, chain, body = entry, (), b"\x00"
+        return _response(status, chain, body)
+
+    return get
+
+
+def _head(statuses):
+    """Stand in for requests.head, answering per URL."""
+
+    def head(url, **kwargs):
+        return _response(statuses[url])
+
+    return head
+
+
+class _BrokenBody:
+    """A body whose transfer dies partway through.
+
+    Modelled on test_mirror.py's _BrokenStream: requests uses raw.stream()
+    when present and translates the urllib3 error it raises into
+    ChunkedEncodingError.
+    """
+
+    def stream(self, chunk_size, decode_content=True):
+        raise ProtocolError("connection broken: incomplete read")
+
+    def read(self, size=-1):
+        raise ProtocolError("connection broken: incomplete read")
+
+    def close(self):
+        pass
+
+
+class CheckMirrorTest(unittest.TestCase):
+    def setUp(self):
+        self.dir = tempfile.mkdtemp()
+        with open(os.path.join(self.dir, "images.yml"), "w") as fp:
+            fp.write(CATALOG)
+
+    def tearDown(self):
+        shutil.rmtree(self.dir)
+
+    def _evaluate(self, head, get):
+        with mock.patch.object(cm.requests, "head", _head(head)):
+            with mock.patch.object(cm.requests, "get", _get(get)):
+                return cm.evaluate(self.dir)
+
+    def test_healthy_objects_are_clean(self):
+        # The real shape, verified against the store: HEAD answers 200 and the
+        # ranged GET answers 206. Reading the GET's status as the manager's
+        # gate would reject exactly this, the case that is fine.
+        report = self._evaluate(
+            head={MIRROR_A: 200, MIRROR_B: 200},
+            get={MIRROR_A: 206, MIRROR_B: 206},
+        )
+
+        self.assertTrue(report.is_empty())
+
+    def test_plain_200_from_both_probes_is_clean(self):
+        report = self._evaluate(
+            head={MIRROR_A: 200, MIRROR_B: 200},
+            get={MIRROR_A: 200, MIRROR_B: 200},
+        )
+
+        self.assertTrue(report.is_empty())
+
+    def test_redirect_that_ends_in_bytes_is_retrievable(self):
+        report = self._evaluate(
+            head={MIRROR_A: 302, MIRROR_B: 200},
+            get={MIRROR_A: (200, (302,)), MIRROR_B: 206},
+        )
+
+        self.assertTrue(report.is_empty())
+
+    def test_redirect_to_a_dead_target_is_not_retrievable(self):
+        # The manager's gate sees only the first response, so a 302 passes it.
+        # The bytes never arrive, so this is still a gap.
+        report = self._evaluate(
+            head={MIRROR_A: 302, MIRROR_B: 200},
+            get={MIRROR_A: (404, (302,)), UPSTREAM_A: 200, MIRROR_B: 206},
+        )
+
+        self.assertEqual([f.shortname for f in report.pending], ["ubuntu-24.04"])
+        self.assertIn("GET 302 -> 404", report.pending[0].mirror_status)
+
+    def test_redirect_the_manager_refuses_is_not_retrievable(self):
+        # Bytes arrive, but main.py:991 accepts only 200 or 302 from its own
+        # HEAD, so a 301 fails the import while the bytes look fine.
+        report = self._evaluate(
+            head={MIRROR_A: 301, MIRROR_B: 200},
+            get={MIRROR_A: 200, UPSTREAM_A: 200, MIRROR_B: 206},
+        )
+
+        self.assertEqual([f.shortname for f in report.pending], ["ubuntu-24.04"])
+        self.assertIn("the manager refuses a 301", report.pending[0].mirror_status)
+
+    def test_absent_object_with_live_upstream_is_pending(self):
+        report = self._evaluate(
+            head={MIRROR_A: 403, MIRROR_B: 200},
+            get={MIRROR_A: 403, UPSTREAM_A: 200, MIRROR_B: 206},
+        )
+
+        self.assertEqual([f.shortname for f in report.pending], ["ubuntu-24.04"])
+        self.assertEqual(report.unmirrorable, [])
+
+    def test_absent_object_with_dead_upstream_is_unmirrorable(self):
+        report = self._evaluate(
+            head={MIRROR_A: 200, MIRROR_B: 403},
+            get={MIRROR_A: 206, MIRROR_B: 403, UPSTREAM_B: 404},
+        )
+
+        self.assertEqual([f.shortname for f in report.unmirrorable], ["almalinux-10"])
+        self.assertEqual(report.pending, [])
+
+    def test_upstream_redirect_still_counts_as_reachable(self):
+        # mirror_version() in contrib/mirror.py downloads upstream with
+        # allow_redirects=True, so a 301 chain upstream is not a problem and
+        # must classify as pending, not unmirrorable. gardenlinux redirects.
+        report = self._evaluate(
+            head={MIRROR_A: 403, MIRROR_B: 200},
+            get={MIRROR_A: 403, UPSTREAM_A: (200, (301,)), MIRROR_B: 206},
+        )
+
+        self.assertEqual([f.shortname for f in report.pending], ["ubuntu-24.04"])
+        self.assertEqual(report.unmirrorable, [])
+
+    def test_403_is_reported_as_a_status_not_as_absence(self):
+        # Hetzner answers 403 for a key that does not exist -- and so does an
+        # object that exists and lost its public read permission. The report
+        # may not claim either, in the fields or in the prose.
+        report = self._evaluate(
+            head={MIRROR_A: 403, MIRROR_B: 200},
+            get={MIRROR_A: 403, UPSTREAM_A: 200, MIRROR_B: 206},
+        )
+
+        self.assertEqual(report.pending[0].mirror_status, "HEAD 403, GET 403")
+
+        text = cm.render(report).lower()
+        for claim in ("missing", "absent", "no copy"):
+            self.assertNotIn(claim, text)
+        self.assertIn("not retrievable", text)
+
+    def test_success_status_with_empty_body_is_not_retrievable(self):
+        # A server can answer a healthy status and then send nothing. That is
+        # not retrievable, and the report must say why, not just repeat the
+        # status a healthy object would also show.
+        for status in (200, 206):
+            with self.subTest(status=status):
+                response = _response(status, body=b"")
+                with mock.patch.object(cm.requests, "get", return_value=response):
+                    arrived, text = cm.fetchable(MIRROR_A)
+
+                self.assertFalse(arrived)
+                self.assertIn("empty body", text)
+                self.assertIn(str(status), text)
+
+    def test_empty_mirror_body_with_live_upstream_is_pending(self):
+        # The classification logic must still route an empty-body mirror as
+        # pending, not unmirrorable, when upstream still has bytes.
+        report = self._evaluate(
+            head={MIRROR_A: 200, MIRROR_B: 200},
+            get={MIRROR_A: (206, (), b""), UPSTREAM_A: 200, MIRROR_B: 206},
+        )
+
+        self.assertEqual([f.shortname for f in report.pending], ["ubuntu-24.04"])
+        self.assertEqual(report.unmirrorable, [])
+        self.assertIn("empty body", report.pending[0].mirror_status)
+
+    def test_transport_failure_is_operational(self):
+        def head(url, **kwargs):
+            raise requests.ConnectionError("name resolution failed")
+
+        with mock.patch.object(cm.time, "sleep"):
+            with mock.patch.object(cm.requests, "head", head):
+                with self.assertRaises(cm.OperationalError):
+                    cm.evaluate(self.dir)
+
+
+class RetryTest(unittest.TestCase):
+    """A single transport hiccup must not fail a probe outright."""
+
+    def test_failure_then_success_returns_the_eventual_verdict(self):
+        # The first GET resets, the second answers 206 -- the probe must
+        # return the successful verdict, not raise.
+        attempts = []
+
+        def get(url, **kwargs):
+            attempts.append(url)
+            if len(attempts) < 2:
+                raise requests.ConnectionError("connection reset")
+            return _response(206)
+
+        with mock.patch.object(cm.time, "sleep") as sleep:
+            with mock.patch.object(cm.requests, "get", get):
+                arrived, status = cm.fetchable(MIRROR_A)
+
+        self.assertTrue(arrived)
+        self.assertEqual(status, "206")
+        self.assertEqual(len(attempts), 2)
+        sleep.assert_called_once()
+
+    def test_every_attempt_failing_raises_operational_error(self):
+        def head(url, **kwargs):
+            raise requests.ConnectionError("connection reset")
+
+        with mock.patch.object(cm.time, "sleep") as sleep:
+            with mock.patch.object(cm.requests, "head", head):
+                with self.assertRaises(cm.OperationalError):
+                    cm.accepted_by_manager(MIRROR_A)
+
+        # Slept between attempts, but not after the last one.
+        self.assertEqual(sleep.call_count, cm.RETRY_ATTEMPTS - 1)
+
+    def test_an_http_status_is_never_retried(self):
+        # A verdict -- even an unwelcome one -- must not trigger a retry.
+        calls = []
+
+        def head(url, **kwargs):
+            calls.append(url)
+            return _response(403)
+
+        with mock.patch.object(cm.time, "sleep") as sleep:
+            with mock.patch.object(cm.requests, "head", head):
+                accepted, status = cm.accepted_by_manager(MIRROR_A)
+
+        self.assertFalse(accepted)
+        self.assertEqual(status, "403")
+        self.assertEqual(len(calls), 1)
+        sleep.assert_not_called()
+
+    def test_non_fetched_status_does_not_read_the_body(self):
+        # A 403's error payload is irrelevant and must not be read.
+        response = _response(403)
+        response.raw = _BrokenBody()
+
+        with mock.patch.object(cm.requests, "get", return_value=response):
+            arrived, status = cm.fetchable(MIRROR_A)
+
+        self.assertFalse(arrived)
+        self.assertEqual(status, "403")
+
+    def test_body_failure_every_attempt_raises_operational_error(self):
+        # The byte read has to sit inside probe()'s retry scope: a body that
+        # dies mid-transfer on every attempt must end up OperationalError,
+        # exactly like a failure while reading the headers.
+        def get(url, **kwargs):
+            response = _response(206)
+            response.raw = _BrokenBody()
+            return response
+
+        with mock.patch.object(cm.time, "sleep") as sleep:
+            with mock.patch.object(cm.requests, "get", get):
+                with self.assertRaises(cm.OperationalError):
+                    cm.fetchable(MIRROR_A)
+
+        self.assertEqual(sleep.call_count, cm.RETRY_ATTEMPTS - 1)
+
+    def test_body_failure_then_success_returns_the_eventual_verdict(self):
+        # The first GET's body dies mid-transfer, the second delivers a byte
+        # -- this is the test that proves the read sits inside the retry
+        # scope, not just the headers.
+        attempts = []
+
+        def get(url, **kwargs):
+            attempts.append(url)
+            response = _response(206)
+            if len(attempts) < 2:
+                response.raw = _BrokenBody()
+            return response
+
+        with mock.patch.object(cm.time, "sleep") as sleep:
+            with mock.patch.object(cm.requests, "get", get):
+                arrived, status = cm.fetchable(MIRROR_A)
+
+        self.assertTrue(arrived)
+        self.assertEqual(status, "206")
+        self.assertEqual(len(attempts), 2)
+        sleep.assert_called_once()
+
+
+class ExitCodeTest(unittest.TestCase):
+    def setUp(self):
+        self.dir = tempfile.mkdtemp()
+        with open(os.path.join(self.dir, "images.yml"), "w") as fp:
+            fp.write(CATALOG)
+
+    def tearDown(self):
+        shutil.rmtree(self.dir)
+
+    def _run(self, head, get):
+        # typer.Exit is a RuntimeError subclass carrying .exit_code, not SystemExit.
+        with mock.patch.object(cm.requests, "head", _head(head)):
+            with mock.patch.object(cm.requests, "get", _get(get)):
+                with self.assertRaises(typer.Exit) as caught:
+                    cm.main(images=self.dir, debug=False)
+        return caught.exception.exit_code
+
+    def test_clean_exits_zero(self):
+        self.assertEqual(
+            self._run(
+                head={MIRROR_A: 200, MIRROR_B: 200},
+                get={MIRROR_A: 206, MIRROR_B: 206},
+            ),
+            0,
+        )
+
+    def test_pending_only_exits_three(self):
+        self.assertEqual(
+            self._run(
+                head={MIRROR_A: 403, MIRROR_B: 200},
+                get={MIRROR_A: 403, UPSTREAM_A: 200, MIRROR_B: 206},
+            ),
+            3,
+        )
+
+    def test_unmirrorable_exits_one(self):
+        self.assertEqual(
+            self._run(
+                head={MIRROR_A: 403, MIRROR_B: 200},
+                get={MIRROR_A: 403, UPSTREAM_A: 404, MIRROR_B: 206},
+            ),
+            1,
+        )
+
+    def test_unmirrorable_wins_over_pending(self):
+        # A run with both must fail everywhere, not be tolerated as pending.
+        self.assertEqual(
+            self._run(
+                head={MIRROR_A: 403, MIRROR_B: 403},
+                get={
+                    MIRROR_A: 403,
+                    UPSTREAM_A: 200,
+                    MIRROR_B: 403,
+                    UPSTREAM_B: 404,
+                },
+            ),
+            1,
+        )
+
+    def test_transport_failure_exits_two(self):
+        def head(url, **kwargs):
+            raise requests.ConnectionError("name resolution failed")
+
+        with mock.patch.object(cm.time, "sleep"):
+            with mock.patch.object(cm.requests, "head", head):
+                with self.assertRaises(typer.Exit) as caught:
+                    cm.main(images=self.dir, debug=False)
+
+        self.assertEqual(caught.exception.exit_code, 2)
+
+    def test_body_failure_every_attempt_exits_two(self):
+        def get(url, **kwargs):
+            response = _response(206)
+            response.raw = _BrokenBody()
+            return response
+
+        with mock.patch.object(cm.time, "sleep"):
+            with mock.patch.object(
+                cm.requests, "head", _head({MIRROR_A: 200, MIRROR_B: 200})
+            ):
+                with mock.patch.object(cm.requests, "get", get):
+                    with self.assertRaises(typer.Exit) as caught:
+                        cm.main(images=self.dir, debug=False)
+
+        self.assertEqual(caught.exception.exit_code, 2)
+
+
+class RenderTest(unittest.TestCase):
+    def test_empty_report_renders_nothing(self):
+        self.assertEqual(cm.render(cm.Report()), "")
+
+    def test_both_classes_are_named_in_the_inventory(self):
+        report = cm.Report(
+            pending=[
+                cm.Finding(
+                    "Ubuntu 26.04",
+                    "ubuntu-26.04",
+                    "20260717",
+                    MIRROR_A,
+                    "HEAD 403, GET 403",
+                    "200",
+                )
+            ],
+            unmirrorable=[
+                cm.Finding(
+                    "CentOS Stream 10",
+                    "centos-stream-10",
+                    "20260902",
+                    MIRROR_B,
+                    "HEAD 403, GET 403",
+                    "404",
+                )
+            ],
+        )
+
+        text = cm.render(report)
+
+        self.assertIn("Ubuntu 26.04 ubuntu-26.04 20260717", text)
+        self.assertIn("CentOS Stream 10 centos-stream-10 20260902", text)
+        self.assertIn("Pending mirror", text)
+        self.assertIn("Unmirrorable", text)
+
+    def test_headings_describe_observations_not_absence(self):
+        report = cm.Report(
+            pending=[
+                cm.Finding(
+                    "Ubuntu 26.04",
+                    "ubuntu-26.04",
+                    "20260717",
+                    MIRROR_A,
+                    "HEAD 403, GET 403",
+                    "200",
+                )
+            ],
+            unmirrorable=[
+                cm.Finding(
+                    "CentOS Stream 10",
+                    "centos-stream-10",
+                    "20260902",
+                    MIRROR_B,
+                    "HEAD 403, GET 403",
+                    "404",
+                )
+            ],
+        )
+
+        text = cm.render(report).lower()
+
+        self.assertIn("mirror not retrievable, upstream retrievable", text)
+        self.assertIn("upstream not retrievable", text)
+        for claim in ("missing", "absent", "no copy"):
+            self.assertNotIn(claim, text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unit/test_mirror.py
+++ b/test/unit/test_mirror.py
@@ -643,5 +643,79 @@ class ExitStatusTest(unittest.TestCase):
         self.assertEqual(len(client.uploaded), 1)
 
 
+SCOPE_YML = """\
+---
+images:
+  - name: Ubuntu 24.04
+    shortname: ubuntu-24.04
+    versions:
+      - version: '20260108'
+        url: https://cloud-images.ubuntu.com/noble/x/noble-server-cloudimg-amd64.img
+        mirror_url: https://object.test/osism/openstack-images/ubuntu-24.04/a.qcow2
+  - name: openSUSE Leap 15.6
+    enable: false
+    shortname: opensuse-leap-15.6
+    versions:
+      - version: '20240603'
+        url: https://ftp.gwdg.de/pub/opensuse/x/Leap-15.6.qcow2
+        mirror_url: https://object.test/osism/openstack-images/opensuse-leap-15.6/b.qcow2
+  - name: Fedora 42
+    shortname: fedora-42
+    versions:
+      - version: '20260101'
+        url: https://download.fedoraproject.org/x/Fedora-Cloud-42.qcow2
+        mirror_url: https://object.test/osism/openstack-images/fedora-42/c.qcow2
+  - name: Ubuntu 22.04
+    shortname: ubuntu-22.04
+    versions:
+      - version: '20260201'
+        url: https://cloud-images.ubuntu.com/jammy/x/jammy-server-cloudimg-amd64.img
+  - name: No Shortname
+    versions:
+      - version: '1'
+        url: https://example.test/x.qcow2
+        mirror_url: https://object.test/osism/openstack-images/x/x.qcow2
+"""
+
+
+class IterMirrorableTest(unittest.TestCase):
+    def setUp(self):
+        self.dir = tempfile.mkdtemp()
+        with open(os.path.join(self.dir, "images.yml"), "w") as fp:
+            fp.write(SCOPE_YML)
+
+    def tearDown(self):
+        shutil.rmtree(self.dir)
+
+    def _yielded(self):
+        return [
+            (image["shortname"], version["version"])
+            for image, version in mirror.iter_mirrorable(self.dir)
+        ]
+
+    def test_allow_listed_image_is_in_scope(self):
+        self.assertIn(("ubuntu-24.04", "20260108"), self._yielded())
+
+    def test_disabled_image_stays_in_scope(self):
+        # mirror.py has never consulted `enable`, and opensuse-leap-15.6 is both
+        # disabled and mirrored. A checker that skipped it would misreport.
+        self.assertIn(("opensuse-leap-15.6", "20240603"), self._yielded())
+
+    def test_shortname_outside_the_allow_list_is_skipped(self):
+        self.assertNotIn(("fedora-42", "20260101"), self._yielded())
+
+    def test_version_without_a_mirror_url_is_skipped(self):
+        self.assertNotIn(("ubuntu-22.04", "20260201"), self._yielded())
+
+    def test_image_without_a_shortname_is_skipped(self):
+        self.assertEqual(len(self._yielded()), 2)
+
+    def test_non_yaml_files_are_ignored(self):
+        with open(os.path.join(self.dir, "notes.txt"), "w") as fp:
+            fp.write("not a definition")
+
+        self.assertEqual(len(self._yielded()), 2)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/unit/test_mirror.py
+++ b/test/unit/test_mirror.py
@@ -131,6 +131,17 @@ def _response(payload=PAYLOAD, status=200):
     return response
 
 
+def _tmp_contents():
+    """Every file left under tmp/, which must be empty after any run."""
+    if not os.path.isdir("tmp"):
+        return []
+    return sorted(
+        os.path.relpath(os.path.join(root, name), "tmp")
+        for root, _, files in os.walk("tmp")
+        for name in files
+    )
+
+
 class MirrorPathsTest(unittest.TestCase):
     def test_plain_image_keeps_a_flat_directory(self):
         paths = mirror.mirror_paths(UBUNTU, UBUNTU["versions"][0])
@@ -531,6 +542,48 @@ class ExtractionFailureTest(unittest.TestCase):
 
         leftovers = [f for f in os.listdir(".") if f != "tmp"]
         self.assertEqual(leftovers, [])
+
+    def test_partial_extraction_leaves_nothing_in_tmp(self):
+        # patoolib can write part of an archive and then fail; those bytes are
+        # a full image's worth of disk and nothing else deletes them.
+        def extract(name, outdir):
+            os.makedirs(outdir, exist_ok=True)
+            with open(os.path.join(outdir, "partial.raw"), "wb") as fp:
+                fp.write(b"partial")
+            raise PatoolError("archive truncated")
+
+        ok, _ = self._mirror(extract)
+
+        self.assertIs(ok, False)
+        self.assertEqual(_tmp_contents(), [])
+
+    def test_archive_siblings_are_not_left_behind(self):
+        # What gardenlinux ships: the image plus other members. Taking only the
+        # image out leaves the siblings behind.
+        target = mirror.mirror_paths(TALOS, TALOS["versions"][0]).filename
+
+        def extract(name, outdir):
+            os.makedirs(outdir, exist_ok=True)
+            for produced in (target, "sibling.txt"):
+                with open(os.path.join(outdir, produced), "wb") as fp:
+                    fp.write(PAYLOAD)
+
+        ok, client = self._mirror(extract)
+
+        self.assertIs(ok, True)
+        self.assertEqual(len(client.uploaded), 1)
+        self.assertEqual(_tmp_contents(), [])
+
+    def test_archive_without_the_expected_image_leaves_nothing_in_tmp(self):
+        def extract(name, outdir):
+            os.makedirs(os.path.join(outdir, "boot"), exist_ok=True)
+            with open(os.path.join(outdir, "boot", "vmlinuz"), "wb") as fp:
+                fp.write(b"kernel")
+
+        ok, _ = self._mirror(extract)
+
+        self.assertIs(ok, False)
+        self.assertEqual(_tmp_contents(), [])
 
 
 SAMPLE_YML = """\

--- a/tox.ini
+++ b/tox.ini
@@ -33,6 +33,10 @@ commands =
 commands =
     python contrib/check_updates.py {posargs}
 
+[testenv:check-mirror]
+commands =
+    python -m contrib.check_mirror {posargs}
+
 [testenv:update-gardenlinux]
 commands =
     python contrib/update-gardenlinux.py


### PR DESCRIPTION
Nothing has run `contrib/mirror.py` automatically since 2024 — the GitHub
workflow went in `855780e` (2021-08-05), the Zuul play in `3c21cc5`
(2024-03-05) — so the catalog can reference objects the object store cannot
serve, with no signal when that happens. Six versions are in that state right
now: `almalinux-10`, `centos-stream-10`, `opensuse-leap-16.0`, `rocky-10`,
`ubuntu-26.04`, `ubuntu-26.04-minimal`, all added by #1260 and all answering
`403`.

That gap has already cost time twice, in both cases diagnosed as something
else:

- #1268
- #1273

## What this does

| Commit | |
|---|---|
| `c39da07` | Fixes a disk leak: `mirror_version()` extracted compressed sources into `tmp/` and never removed what it extracted (9 of 39 in-scope versions are compressed) |
| `8261b89` | Extracts the mirror's scope predicate as `iter_mirrorable()`, so a checker cannot drift from the uploader |
| `aeade6e` | Adds `contrib/check_mirror.py`, a credential-free checker, plus the `check-mirror` tox env |
| `13da934` | Wires two credential-free Zuul jobs and lands three playbooks, two of them inert |
| `4da8b42` | Documents the lifecycle in `README.md` |

The checker probes anonymously, because that is how the system actually
operates: `main.py` hands Glance a plain `mirror_url` with no credentials, and
nothing in `mirror.py` verifies an object after upload. A mirrored object must
satisfy two independent conditions — the non-following `HEAD` gate `main.py`
itself applies before importing (`200`/`302` only), and a ranged `GET`
following redirects that ends in bytes actually read. Neither implies the
other: a `301` the manager refuses still serves bytes fine over `GET`, the
gardenlinux upstream URLs answer `302` so trusting the first status alone would
pass a redirect to a target that is gone, and with `stream=True` a status-only
check would call a zero-byte object healthy.

Gaps are reported in two classes — *pending mirror* (an upload is owed) and
*unmirrorable* (the pin must be bumped first) — and never as "missing": the
store answers `403` both for a key that was never uploaded and for one that
lost public read permission, and the fix differs.

Exit codes are the contract the jobs read: `0` clean, `1` unmirrorable, `2` no
verdict reached, `3` pending only. `check-upstream` tolerates `3`, so a change
adding a version passes; `periodic-daily` does not.

## What is deliberately NOT here

The encrypted secret and the credentialed upload job. Nobody currently holds
the object-store keys, and a placeholder `!encrypted/pkcs1-oaep` value is a
Zuul **configuration syntax error for the whole project**, not just for that
job. `README.md` carries the exact block to add — secret name, data keys and
binding deliberately identical to the job removed in `3c21cc5`, so an earlier
runbook still applies — behind that warning.

Consequence, stated plainly: **`periodic-daily` goes red on merge** and stays
red until someone with the keys runs an upload. That is the designed signal,
not a defect. `check` stays green.

## Things a reviewer may want to poke at

- `files:` on `check-upstream` is an anchored regex, `'^etc/images/.*\.yml$'`,
  not a glob. Zuul treats `files:` as regular expressions, and
  `etc/images/*.yml` as a regex matches nothing here — the job would never run,
  silently. (The repo's pre-existing `irrelevant-files: - etc/images/*` works
  by accident, since `etc/images` plus zero-or-more slashes matches as a
  prefix.)
- The accepted-exit-code variable is set per job with **no** default in the
  playbook. Zuul passes job vars into the inventory as `all`-group variables
  and Ansible ranks play vars above those, so a default in the playbook would
  override both jobs and quietly make the daily check tolerant. An `assert`
  task fails a job that forgets it.
- The upload playbook keeps `no_log: true` on the credentialed task and asserts
  both secret keys are defined first, because `no_log` would otherwise censor
  Ansible's own "undefined variable" message on the first run of a job nobody
  has ever run.

## Testing

`tox -e test -- test/unit`: 140 tests, and green at **every** commit in the
series (107 / 113 / 140 / 140 / 140), not just at the tip. `flake8`, `black`,
`mypy`, `yamllint` clean. The checker was also run against the live store: exit
`3`, listing exactly the six versions above.

The Zuul job definitions themselves were not executed — there is no local Zuul
— so those are review-by-reading.

## Merge order

This conflicts textually with one open PR, which adds `"cirros"` to the inline
allow-list inside `main()` that `8261b89` replaces with a module-level
constant:

- #1273

Whichever lands second moves that one line into `MIRRORED_SHORTNAME_PREFIXES`.
Landing this one first makes that a trivial one-line diff. This PR does not
unblock it — its integration test imports Cirros from a `mirror_url` whose
object does not exist, and only an actual upload fixes that (filed separately
as an integration-test design issue).
